### PR TITLE
Gets the banking ticket HTML by cUrl with url fopen fallback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.5.4
+* Improvement - Gets the banking ticket HTML by cUrl with url fopen fallback [#345](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/345)
+* Improvement - Changed iframe boleto URL fetching to avoid xss injections [#345](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/345)
+
 ## 1.5.3
 * Fix - In case user country was not set one-click payments was crashing [#343](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/343)
 

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-banking-ticket-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-banking-ticket-gateway.php
@@ -131,6 +131,7 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_Gateway
 		$customer_email = get_post_meta($order->id, '_billing_email', true);
 		$customer_name = get_post_meta($order->id, '_billing_first_name', true);
 		$boleto_due_date = get_post_meta($order->id, '_payment_due_date', true);
+		$boleto_hash = get_post_meta($order->id, '_ebanx_payment_hash', true);
 
 		$barcode_anti_fraud = WC_EBANX_Banking_Ticket_Gateway::barcode_anti_fraud($barcode);
 
@@ -141,7 +142,7 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_Gateway
 				'url_basic'       => $boleto_basic,
 				'url_pdf'         => $boleto_pdf,
 				'url_print'       => $boleto_print,
-				'url_iframe'      => get_site_url() . '/?ebanx=order-received&url=' . $boleto_basic,
+				'url_iframe'      => get_site_url() . '/?ebanx=order-received&hash=' . $boleto_hash,
 				'customer_email'  => $customer_email,
 				'customer_name'   => $customer_name,
 				'due_date'        => $boleto_due_date,

--- a/woocommerce-gateway-ebanx/readme.txt
+++ b/woocommerce-gateway-ebanx/readme.txt
@@ -135,6 +135,10 @@ Yes, you can.
 
 == Changelog ==
 
+= 1.5.4 =
+* Improvement - Gets the banking ticket HTML by cUrl with url fopen fallback [#345](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/345)
+* Improvement - Changed iframe boleto URL fetching to avoid xss injections [#345](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/345)
+
 = 1.5.3 =
 * Fix - In case user country was not set one-click payments was crashing [#343](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/343)
 

--- a/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
@@ -142,8 +142,11 @@ if (!class_exists('WC_EBANX')) {
 		 */
 		public function ebanx_order_received()
 		{
-			if (isset($_GET['ebanx']) && $_GET['ebanx'] === 'order-received' && isset($_GET['url'])) {
-				$url = $_GET['url'];
+			if (isset($_GET['ebanx']) && $_GET['ebanx'] === 'order-received' && isset($_GET['hash'])) {
+				$this->setup_configs();
+				$hash = $_GET['hash'];
+				$subdomain = $this->is_sandbox_mode ? 'sandbox' : 'print';
+				$url = 'https://'.$subdomain.'.ebanx.com/print/?hash=' . $hash . '&format=basic#';
 				if (in_array('curl', get_loaded_extensions())) {
 					$c = curl_init($url);
 					curl_setopt($c, CURLOPT_RETURNTRANSFER, true);

--- a/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
@@ -135,10 +135,30 @@ if (!class_exists('WC_EBANX')) {
 			}
 		}
 
+		/**
+		 * Gets the banking ticket HTML by cUrl with url fopen fallback
+		 *
+		 * @return void
+		 */
 		public function ebanx_order_received()
 		{
 			if (isset($_GET['ebanx']) && $_GET['ebanx'] === 'order-received' && isset($_GET['url'])) {
-				echo file_get_contents($_GET['url']);
+				$url = $_GET['url'];
+				if (in_array('curl', get_loaded_extensions())) {
+					$c = curl_init($url);
+					curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
+					$html = curl_exec($c);
+
+					if (curl_error($c))
+					    die(curl_error($c));
+
+					curl_close($c);
+
+					echo $html;
+					exit;
+				}
+
+				echo file_get_contents($url);
 				exit;
 			}
 		}

--- a/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
@@ -148,17 +148,15 @@ if (!class_exists('WC_EBANX')) {
 				$subdomain = $this->is_sandbox_mode ? 'sandbox' : 'print';
 				$url = 'https://'.$subdomain.'.ebanx.com/print/?hash=' . $hash . '&format=basic#';
 				if (in_array('curl', get_loaded_extensions())) {
-					$c = curl_init($url);
-					curl_setopt($c, CURLOPT_RETURNTRANSFER, true);
-					$html = curl_exec($c);
+					$curl = curl_init($url);
+					curl_setopt($curl, CURLOPT_RETURNTRANSFER, true);
+					$html = curl_exec($curl);
 
-					if (curl_error($c))
-					    die(curl_error($c));
-
-					curl_close($c);
-
-					echo $html;
-					exit;
+					if (!curl_error($curl)) {
+					    curl_close($curl);
+						echo $html;
+						exit;
+					}
 				}
 
 				echo file_get_contents($url);


### PR DESCRIPTION
This pull request prevents us from using `file_get_contents` on an external url, which requires the merchant server to have the `allow_url_fopen` enabled. This is security liability.
Some hosts don't even allow the setting to be changed, requiring lengthy phone calls.
This pull also removes the full url construct from our boleto iframe to prevent xss.