### PR TITLE
Refactored third-party request processing to use a simple router

### DIFF
--- a/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
@@ -135,6 +135,11 @@ if (!class_exists('WC_EBANX')) {
 			}
 		}
 
+		/**
+		 * Check if it is receiving a third-party request and routes it
+		 *
+		 * @return void
+		 */
 		public function ebanx_router()
 		{
 			if (isset($_GET['ebanx'])) {


### PR DESCRIPTION
Now the plugin can easily check and respond to any request we configure on the router. We just need to create a private method, setup the needed action on `ebanx_router()` and call that private method.
Besides that, now we have standardized all plugin requests to use the GET key 'ebanx' with the desired action as value. 