### PR TITLE
Removed unnecessary properties and variables

### DIFF
--- a/woocommerce-gateway-ebanx/assets/css/paying-via-ebanx.css
+++ b/woocommerce-gateway-ebanx/assets/css/paying-via-ebanx.css
@@ -32,10 +32,7 @@ li[class*="ebanx"] .ebanx-payment-container.ebanx-language-br:after {
   background-image: url(../images/ebanx-pagando.png);
 }
 
-li[class*="ebanx"] .ebanx-payment-container.ebanx-language-mx:after,
-li[class*="ebanx"] .ebanx-payment-container.ebanx-language-pe:after,
-li[class*="ebanx"] .ebanx-payment-container.ebanx-language-co:after,
-li[class*="ebanx"] .ebanx-payment-container.ebanx-language-cl:after {
+li[class*="ebanx"] .ebanx-payment-container.ebanx-language-es:after {
   width: 168px;
 
   background-image: url(../images/ebanx-estas-pagando.png);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-account-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-account-gateway.php
@@ -69,9 +69,7 @@ class WC_EBANX_Account_Gateway extends WC_EBANX_Redirect_Gateway
 
 		wc_get_template(
 			'account/payment-form.php',
-			array(
-				'language' => $this->language,
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-baloto-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-baloto-gateway.php
@@ -54,9 +54,7 @@ class WC_EBANX_Baloto_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'baloto/payment-form.php',
-			array(
-				'language' => $this->language,
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-banking-ticket-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-banking-ticket-gateway.php
@@ -53,9 +53,7 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'banking-ticket/checkout-instructions.php',
-			array(
-				'language' => $this->language,
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-credit-card-br-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-credit-card-br-gateway.php
@@ -100,7 +100,6 @@ class WC_EBANX_Credit_Card_BR_Gateway extends WC_EBANX_Credit_Card_Gateway
 		wc_get_template(
 			'ebanx-credit-card-br/payment-form.php',
 			array(
-				'language' => $this->language,
 				'cards' => (array) $cards,
 				'cart_total' => $cart_total,
 				'max_installment' => min($this->configs->settings['credit_card_instalments'], $max_instalments),

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-credit-card-mx-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-credit-card-mx-gateway.php
@@ -56,7 +56,6 @@ class WC_EBANX_Credit_Card_MX_Gateway extends WC_EBANX_Credit_Card_Gateway
 		wc_get_template(
 			'ebanx-credit-card-mx/payment-form.php',
 			array(
-				'language' => $this->language,
 				'cards' => (array) $cards,
 				'cart_total' => $cart_total,
 				'country' => $this->getTransactionAddress('country'),

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-debit-card-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-debit-card-gateway.php
@@ -69,7 +69,6 @@ class WC_EBANX_Debit_Card_Gateway extends WC_EBANX_Gateway
 		wc_get_template(
 			'debit-card/payment-form.php',
 			array(
-				'language' => $this->language,
 				'cart_total' => $this->get_order_total()
 			),
 			'woocommerce/ebanx/',

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-eft-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-eft-gateway.php
@@ -54,7 +54,6 @@ class WC_EBANX_Eft_Gateway extends WC_EBANX_Redirect_Gateway
 		wc_get_template(
 			'eft/payment-form.php',
 			array(
-				'language' => $this->language,
 				'title'       => $this->title,
 				'description' => $this->description,
 				'banks'       => WC_EBANX_Gateway_Utils::$BANKS_EFT_ALLOWED[WC_EBANX_Gateway_Utils::COUNTRY_COLOMBIA]

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-gateway.php
@@ -662,7 +662,7 @@ abstract class WC_EBANX_Gateway extends WC_Payment_Gateway
 			));
 		} catch (Exception $e) {
 
-			$this->language = $this->getTransactionAddress('country');
+			$country = $this->getTransactionAddress('country');
 
 			$code = $e->getMessage();
 
@@ -673,7 +673,7 @@ abstract class WC_EBANX_Gateway extends WC_Payment_Gateway
 				'co' => 'es',
 				'br' => 'pt-br',
 			);
-			$language = $languages[$this->language];
+			$language = $languages[$country];
 
 			$errors = array(
 				'pt-br' => array(

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-oxxo-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-oxxo-gateway.php
@@ -53,9 +53,7 @@ class WC_EBANX_Oxxo_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'oxxo/payment-form.php',
-			array(
-				'language' => $this->language,
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-pagoefectivo-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-pagoefectivo-gateway.php
@@ -53,9 +53,7 @@ class WC_EBANX_Pagoefectivo_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'pagoefectivo/payment-form.php',
-			array(
-				'language'    => $this->language,
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-safetypay-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-safetypay-gateway.php
@@ -70,7 +70,6 @@ class WC_EBANX_Safetypay_Gateway extends WC_EBANX_Redirect_Gateway
 		wc_get_template(
 			'safetypay/payment-form.php',
 			array(
-				'language' => $this->language,
 				'title'       => $this->title,
 				'description' => $this->description,
 			),

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-sencillito-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-sencillito-gateway.php
@@ -67,9 +67,7 @@ class WC_EBANX_Sencillito_Gateway extends WC_EBANX_Redirect_Gateway
 
 		wc_get_template(
 			'sencillito/payment-form.php',
-			array(
-				'language' => $this->language
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-servipag-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-servipag-gateway.php
@@ -53,9 +53,7 @@ class WC_EBANX_Servipag_Gateway extends WC_EBANX_Redirect_Gateway
 
 		wc_get_template(
 			'servipag/payment-form.php',
-			array(
-				'language' => $this->language,
-			),
+			array(),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/includes/class-wc-ebanx-tef-gateway.php
+++ b/woocommerce-gateway-ebanx/includes/class-wc-ebanx-tef-gateway.php
@@ -53,7 +53,6 @@ class WC_EBANX_Tef_Gateway extends WC_EBANX_Redirect_Gateway
 		wc_get_template(
 			'tef/payment-form.php',
 			array(
-				'language' => $this->language,
 				'title'       => $this->title,
 				'description' => $this->description,
 			),

--- a/woocommerce-gateway-ebanx/templates/account/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/account/payment-form.php
@@ -12,4 +12,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-account" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-account" class="ebanx-payment-container ebanx-language-br"></div>

--- a/woocommerce-gateway-ebanx/templates/baloto/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/baloto/payment-form.php
@@ -11,4 +11,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-baloto-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-baloto-payment" class="ebanx-payment-container ebanx-language-es"></div>

--- a/woocommerce-gateway-ebanx/templates/banking-ticket/checkout-instructions.php
+++ b/woocommerce-gateway-ebanx/templates/banking-ticket/checkout-instructions.php
@@ -12,4 +12,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-banking-ticket" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-banking-ticket" class="ebanx-payment-container ebanx-language-br"></div>

--- a/woocommerce-gateway-ebanx/templates/debit-card/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/debit-card/payment-form.php
@@ -5,7 +5,7 @@ if (!defined('ABSPATH')) {
 }
 ?>
 
-<div id="ebanx-debit-cart-form" class="ebanx-payment-container ebanx-language-<?php echo $language ?>">
+<div id="ebanx-debit-cart-form" class="ebanx-payment-container ebanx-language-es">
 	<div id="ebanx-container-new-debit-card">
 		<section class="ebanx-form-row">
 			<label for="ebanx-debit-card-holder-name"><?php _e('Titular de la tarjeta', 'woocommerce-gateway-ebanx') ?> <span class="required">*</span></label>

--- a/woocommerce-gateway-ebanx/templates/ebanx-credit-card-br/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/ebanx-credit-card-br/payment-form.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
 }
 ?>
 
-<div id="ebanx-credit-cart-form" class="ebanx-payment-container ebanx-language-<?php echo $language ?>">
+<div id="ebanx-credit-cart-form" class="ebanx-payment-container ebanx-language-br">
     <section class="ebanx-form-row">
     	<?php if (!empty($cards)): ?>
     		<?php foreach ($cards as $k => $card): ?>

--- a/woocommerce-gateway-ebanx/templates/ebanx-credit-card-mx/card-template.php
+++ b/woocommerce-gateway-ebanx/templates/ebanx-credit-card-mx/card-template.php
@@ -1,4 +1,4 @@
-<div class="ebanx-credit-card-template ebanx-language-<?php echo $language ?>">
+<div class="ebanx-credit-card-template ebanx-language-es">
     <section class="ebanx-form-row">
         <label for="ebanx-card-holder-name"><?php _e('Titular de la tarjeta', 'woocommerce-gateway-ebanx'); ?><span class="required">*</span></label>
         <input id="ebanx-card-holder-name" class="wc-credit-card-form-card-name input-text" type="text" autocomplete="off" />

--- a/woocommerce-gateway-ebanx/templates/ebanx-credit-card-mx/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/ebanx-credit-card-mx/payment-form.php
@@ -12,7 +12,7 @@ if (!defined('ABSPATH')) {
 }
 ?>
 
-<div id="ebanx-credit-cart-form" class="ebanx-payment-container ebanx-language-<?php echo $language ?>">
+<div id="ebanx-credit-cart-form" class="ebanx-payment-container ebanx-language-es">
     <section class="ebanx-form-row">
     	<?php if (!empty($cards)): ?>
     		<?php foreach ($cards as $k => $card): ?>

--- a/woocommerce-gateway-ebanx/templates/eft/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/eft/payment-form.php
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 asort($banks);
 ?>
 
-<div id="ebanx-eft-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>">
+<div id="ebanx-eft-payment" class="ebanx-payment-container ebanx-language-es">
     <select name="eft" class="ebanx-select-field">
         <?php foreach($banks as $key => $bank): ?>
         	<option value="<?php echo $key ?>"><?php echo $bank ?></option>

--- a/woocommerce-gateway-ebanx/templates/oxxo/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/oxxo/payment-form.php
@@ -12,4 +12,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-oxxo-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-oxxo-payment" class="ebanx-payment-container ebanx-language-es"></div>

--- a/woocommerce-gateway-ebanx/templates/pagoefectivo/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/pagoefectivo/payment-form.php
@@ -12,4 +12,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-pagoefectivo-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-pagoefectivo-payment" class="ebanx-payment-container ebanx-language-es"></div>

--- a/woocommerce-gateway-ebanx/templates/safetypay/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/safetypay/payment-form.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-safetypay-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>">
+<div id="ebanx-safetypay-payment" class="ebanx-payment-container ebanx-language-es">
   <div class="ebanx-form-row">
 		<label class="ebanx-label">
 			<input type="radio" name="safetypay" value="cash" checked> Cash

--- a/woocommerce-gateway-ebanx/templates/sencillito/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/sencillito/payment-form.php
@@ -12,4 +12,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-sencillito" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-sencillito" class="ebanx-payment-container ebanx-language-es"></div>

--- a/woocommerce-gateway-ebanx/templates/servipag/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/servipag/payment-form.php
@@ -12,4 +12,4 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-servipag-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>"></div>
+<div id="ebanx-servipag-payment" class="ebanx-payment-container ebanx-language-es"></div>

--- a/woocommerce-gateway-ebanx/templates/tef/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/tef/payment-form.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-tef-payment" class="ebanx-payment-container ebanx-language-<?php echo $language ?>">
+<div id="ebanx-tef-payment" class="ebanx-payment-container ebanx-language-br">
 	<p>
 		<label class="ebanx-label">
 			<input type="radio" name="tef" value="itau" checked> Itaú


### PR DESCRIPTION
It was removed unnecessaries properties and variables from plugin, because the plugin it was using a older structure to show the payment confirmation. It was updated this structure and we doesn't need anymore these properties and variables.