### PR TITLE
Getting the plugin version automatically

### DIFF
--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-banking-ticket-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-banking-ticket-gateway.php
@@ -157,14 +157,14 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_Gateway
 			'woocommerce_ebanx_clipboard',
 			plugins_url('assets/js/vendor/clipboard.min.js', WC_EBANX::DIR),
 			array(),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 		wp_enqueue_script(
 			'woocommerce_ebanx_order_received',
 			plugins_url('assets/js/order-received.js', WC_EBANX::DIR),
 			array('jquery'),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 	}

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -88,8 +88,8 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_Gateway
 			wp_enqueue_script('wc-credit-card-form');
 			// Using // to avoid conflicts between http and https protocols
 			wp_enqueue_script('ebanx', '//js.ebanx.com/ebanx-1.5.min.js', '', null, true);
-			wp_enqueue_script('woocommerce_ebanx_jquery_mask', plugins_url('assets/js/jquery-mask.js', WC_EBANX::DIR), array('jquery'), WC_EBANX::VERSION, true);
-			wp_enqueue_script('woocommerce_ebanx', plugins_url('assets/js/credit-card.js', WC_EBANX::DIR), array('jquery-payment', 'ebanx'), WC_EBANX::VERSION, true);
+			wp_enqueue_script('woocommerce_ebanx_jquery_mask', plugins_url('assets/js/jquery-mask.js', WC_EBANX::DIR), array('jquery'), WC_EBANX::get_plugin_version(), true);
+			wp_enqueue_script('woocommerce_ebanx', plugins_url('assets/js/credit-card.js', WC_EBANX::DIR), array('jquery-payment', 'ebanx'), WC_EBANX::get_plugin_version(), true);
 
 			// If we're on the checkout page we need to pass ebanx.js the address of the order.
 			if (is_checkout_pay_page() && isset($_GET['order']) && isset($_GET['order_id'])) {

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-debit-card-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-debit-card-gateway.php
@@ -51,7 +51,7 @@ class WC_EBANX_Debit_Card_Gateway extends WC_EBANX_Gateway
 	{
 		if (is_checkout()) {
 			wp_enqueue_script('wc-debit-card-form');
-			wp_enqueue_script('woocommerce_ebanx_debit', plugins_url('assets/js/debit-card.js', WC_EBANX::DIR), array('jquery-payment'), WC_EBANX::VERSION, true);
+			wp_enqueue_script('woocommerce_ebanx_debit', plugins_url('assets/js/debit-card.js', WC_EBANX::DIR), array('jquery-payment'), WC_EBANX::get_plugin_version(), true);
 		}
 
 		parent::checkout_assets();

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
@@ -285,7 +285,7 @@ abstract class WC_EBANX_Gateway extends WC_Payment_Gateway
 				'woocommerce_ebanx_checkout_fields',
 				plugins_url('assets/js/checkout-fields.js', WC_EBANX::DIR),
 				array('jquery'),
-				WC_EBANX::VERSION,
+				WC_EBANX::get_plugin_version(),
 				true
 			);
 		}
@@ -459,7 +459,7 @@ abstract class WC_EBANX_Gateway extends WC_Payment_Gateway
 				'notification_url'      => $home_url,
 				'redirect_url'          => $home_url,
 				'user_value_1'          => 'from_woocommerce',
-				'user_value_3'          => 'version=' . WC_EBANX::VERSION,
+				'user_value_3'          => 'version=' . WC_EBANX::get_plugin_version(),
 				'country'               => $order->billing_country,
 				'currency_code'         => $this->merchant_currency,
 				'name'                  => $order->billing_first_name . ' ' . $order->billing_last_name,

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-oxxo-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-oxxo-gateway.php
@@ -113,14 +113,14 @@ class WC_EBANX_Oxxo_Gateway extends WC_EBANX_Gateway
 			'woocommerce_ebanx_clipboard',
 			plugins_url('assets/js/vendor/clipboard.min.js', WC_EBANX::DIR),
 			array(),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 		wp_enqueue_script(
 			'woocommerce_ebanx_order_received',
 			plugins_url('assets/js/order-received.js', WC_EBANX::DIR),
 			array('jquery'),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 	}

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-pagoefectivo-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-pagoefectivo-gateway.php
@@ -21,6 +21,8 @@ class WC_EBANX_Pagoefectivo_Gateway extends WC_EBANX_Gateway
 		parent::__construct();
 
 		$this->enabled = is_array($this->configs->settings['peru_payment_methods']) ? in_array($this->id, $this->configs->settings['peru_payment_methods']) ? 'yes' : false : false;
+
+		echo WC_EBANX::get_plugin_version();
 	}
 
 	/**
@@ -102,14 +104,14 @@ class WC_EBANX_Pagoefectivo_Gateway extends WC_EBANX_Gateway
 			'woocommerce_ebanx_clipboard',
 			plugins_url('assets/js/vendor/clipboard.min.js', WC_EBANX::DIR),
 			array(),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 		wp_enqueue_script(
 			'woocommerce_ebanx_order_received',
 			plugins_url('assets/js/order-received.js', WC_EBANX::DIR),
 			array('jquery'),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 	}

--- a/woocommerce-gateway-ebanx/services/class-wc-ebanx-one-click.php
+++ b/woocommerce-gateway-ebanx/services/class-wc-ebanx-one-click.php
@@ -359,7 +359,7 @@ class WC_EBANX_One_Click {
 			'woocommerce_ebanx_one_click_script',
 			plugins_url( 'assets/js/one-click.js', WC_EBANX::DIR ),
 			array(),
-			WC_EBANX::VERSION,
+			WC_EBANX::get_plugin_version(),
 			true
 		);
 

--- a/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
@@ -44,8 +44,6 @@ if (!class_exists('WC_EBANX')) {
 		 *
 		 * @var string
 		 */
-		const VERSION = '1.10.1';
-
 		const DIR = __FILE__;
 
 		/**
@@ -133,6 +131,26 @@ if (!class_exists('WC_EBANX')) {
 			$this->is_sandbox_mode = $this->configs->settings['sandbox_mode_enabled'] === 'yes';
 			$this->private_key = $this->is_sandbox_mode ? $this->configs->settings['sandbox_private_key'] : $this->configs->settings['live_private_key'];
 			$this->public_key = $this->is_sandbox_mode ? $this->configs->settings['sandbox_public_key'] : $this->configs->settings['live_public_key'];
+		}
+
+		/**
+		 * Extract some informations from the plugin
+		 * @param  string $info The information that you want to extract, possible values: version, name, description, author, network
+		 * @return string       The value extracted
+		 */
+		public static function get_plugin_info($info = 'name') {
+			$plugin = get_file_data(__FILE__, array($info => $info));
+
+			return $plugin[$info];
+		}
+
+		/**
+		 * Extract the plugin version described on plugin's header
+		 *
+		 * @return string The plugin version
+		 */
+		public static function get_plugin_version() {
+			return self::get_plugin_info('version');
 		}
 
 		/**
@@ -670,14 +688,14 @@ if (!class_exists('WC_EBANX')) {
 				'woocommerce_ebanx_payments_options',
 				plugins_url('assets/js/payments-options.js', WC_EBANX::DIR),
 				array('jquery'),
-				WC_EBANX::VERSION,
+				WC_EBANX::get_plugin_version(),
 				true
 			);
 			wp_enqueue_script(
 				'woocommerce_ebanx_advanced_options',
 				plugins_url('assets/js/advanced-options.js', WC_EBANX::DIR),
 				array('jquery'),
-				WC_EBANX::VERSION,
+				WC_EBANX::get_plugin_version(),
 				true
 			);
 		}


### PR DESCRIPTION
A partir de agora o processo de deploy será mais fácil, pois atualizaremos a versão do plugin em apenas 1 local e não mais em uma constante da classe pai, agilizando o processo de deploy e evitando esquecimentos.