### PR TITLE
Pay for oder

### DIFF
--- a/woocommerce-gateway-ebanx/assets/css/paying-via-ebanx.css
+++ b/woocommerce-gateway-ebanx/assets/css/paying-via-ebanx.css
@@ -470,3 +470,7 @@ li[class*="ebanx"] .payment_box .ebanx-credit-card-label > .ebanx-credit-card-bi
 .ebanx-form-row .select2.select2-container {
   width: 100% !important;
 }
+
+.ebanx-compliance-fields {
+  margin-bottom: 30px;
+}

--- a/woocommerce-gateway-ebanx/assets/js/checkout-fields.js
+++ b/woocommerce-gateway-ebanx/assets/js/checkout-fields.js
@@ -6,10 +6,14 @@ jQuery (function ($) {
   }
 
   // Masks
-  $(document).find(".ebanx_billing_chile_birth_date input").mask('00/00/0000');
-  $(document).find(".ebanx_billing_brazil_birth_date input").mask('00/00/0000');
-  $(document).find(".ebanx_billing_brazil_document input").mask('000.000.000-00');
-  $(document).find(".ebanx_billing_brazil_cnpj input").mask('00.000.000/0000-00');
+  $(document).find('.ebanx_billing_chile_birth_date input').mask('00/00/0000');
+  $(document).find('.ebanx_billing_brazil_birth_date input').mask('00/00/0000');
+  $(document).find('.ebanx_billing_brazil_document input').mask('000.000.000-00');
+  $(document).find('.ebanx_billing_brazil_cnpj input').mask('00.000.000/0000-00');
+
+  $(document).find('input[name*="_birth_date"]').mask('00/00/0000');
+  $(document).find('input[name*="brazil_document"]').mask('000.000.000-00');
+  $(document).find('input[name*="brazil_cnpj"]').mask('00.000.000/0000-00');
 
   var getBillingFields = function (filter) {
     filter = filter || '';
@@ -66,9 +70,9 @@ jQuery (function ($) {
   $('#billing_country')
     .on('change',function() {
       var country = this.value.toLowerCase();
-      
+
       disableFields(getBillingFields());
-      
+
       if (country) {
         enableFields(getBillingFields(country));
       }

--- a/woocommerce-gateway-ebanx/assets/js/credit-card.js
+++ b/woocommerce-gateway-ebanx/assets/js/credit-card.js
@@ -87,7 +87,7 @@ jQuery( function($) {
 				var cvv       = $('#ebanx-card-cvv').val();
 				var expires   = $('#ebanx-card-expiry').payment('cardExpiryVal');
 				var card_name = $('#ebanx-card-holder-name').val() || ($('#billing_first_name').val() + ' ' + $('#billing_last_name').val());
-				var country   = $('#billing_country').val().toLowerCase();
+				var country   = $('#billing_country, input[name*="billing_country"]').val().toLowerCase();
         var instalments = $('#ebanx-container-new-credit-card').find('select.ebanx-instalments').val();
 
 				EBANX.config.setCountry(country);
@@ -191,6 +191,7 @@ jQuery( function($) {
 		var country = self.attr('data-country');
 		var amount = self.attr('data-amount');
 		var currency = self.attr('data-currency');
+		var order_id = self.attr('data-order-id');
 		var text = self.parents('.payment_box').find('.ebanx-payment-converted-amount span');
 		var spinner = self.parents('.payment_box').find('.ebanx-spinner');
 
@@ -204,7 +205,8 @@ jQuery( function($) {
         instalments: instalments,
         country: country,
         amount: amount,
-        currency: currency
+        currency: currency,
+        order_id: order_id
       }
 		})
 			.done(function (data) {

--- a/woocommerce-gateway-ebanx/assets/js/debit-card.js
+++ b/woocommerce-gateway-ebanx/assets/js/debit-card.js
@@ -72,7 +72,7 @@ jQuery( function($) {
 				var cvv       = $('#ebanx-debit-card-cvv').val();
 				var expires   = $('#ebanx-debit-card-expiry').payment('cardExpiryVal');
 				var card_name = $('#ebanx-debit-card-holder-name').val();
-				var country   = $('#billing_country').val().toLowerCase();
+				var country   = $('#billing_country, input[name*="billing_country"]').val().toLowerCase();
 
 				EBANX.config.setCountry(country);
 

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-account-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-account-gateway.php
@@ -70,7 +70,9 @@ class WC_EBANX_Account_Gateway extends WC_EBANX_Redirect_Gateway
 
 		wc_get_template(
 			'account/payment-form.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-baloto-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-baloto-gateway.php
@@ -54,7 +54,9 @@ class WC_EBANX_Baloto_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'baloto/payment-form.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-banking-ticket-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-banking-ticket-gateway.php
@@ -54,7 +54,9 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'banking-ticket/checkout-instructions.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -480,6 +480,7 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_Gateway
 				'cart_total' => $cart_total,
 				'place_order_enabled' => $save_card,
 				'instalments' => $country === WC_EBANX_Constants::COUNTRY_BRAZIL ? 'Número de parcelas' :  'Meses sin intereses',
+				'id' => $this->id
 			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-debit-card-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-debit-card-gateway.php
@@ -70,7 +70,8 @@ class WC_EBANX_Debit_Card_Gateway extends WC_EBANX_Gateway
 		wc_get_template(
 			'debit-card/payment-form.php',
 			array(
-				'cart_total' => $this->get_order_total()
+				'cart_total' => $this->get_order_total(),
+				'id' => $this->id
 			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-eft-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-eft-gateway.php
@@ -57,7 +57,8 @@ class WC_EBANX_Eft_Gateway extends WC_EBANX_Redirect_Gateway
 			array(
 				'title'       => $this->title,
 				'description' => $this->description,
-				'banks'       => WC_EBANX_Constants::$BANKS_EFT_ALLOWED[WC_EBANX_Constants::COUNTRY_COLOMBIA]
+				'banks'       => WC_EBANX_Constants::$BANKS_EFT_ALLOWED[WC_EBANX_Constants::COUNTRY_COLOMBIA],
+				'id' => $this->id
 			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
@@ -99,11 +99,29 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 
 		return parent::is_available()
 			&& $this->enabled === 'yes'
+			&& $this->is_gateway()
 			&& !empty($this->public_key)
 			&& !empty($this->private_key)
 			&& ($this->currency_is_usd_eur($currency)
 			|| $this->ebanx_process_merchant_currency($currency)
 			);
+	}
+
+	/**
+	* Detects if the page only accepts the selected gateways.
+	*
+	* @return boolean
+	*/
+	public function is_gateway()
+	{
+		$order_id = get_query_var('order-pay');
+		$order = wc_get_order($order_id);
+
+		if ($order && !empty($order->get_payment_method())) {
+			return $order->get_payment_method() === $this->id;
+		}
+
+		return true;
 	}
 
 	/**
@@ -474,6 +492,8 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 
 	/**
 	* Gets the necessary data to send to EBANX APIs.
+	*
+	* @return array
 	*/
 	protected function get_data()
 	{

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
@@ -99,7 +99,7 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 
 		return parent::is_available()
 			&& $this->enabled === 'yes'
-			&& $this->is_gateway()
+			&& $this->is_current_order_gateway()
 			&& !empty($this->public_key)
 			&& !empty($this->private_key)
 			&& ($this->currency_is_usd_eur($currency)
@@ -112,7 +112,7 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 	*
 	* @return boolean
 	*/
-	public function is_gateway()
+	public function is_current_order_gateway()
 	{
 		$order_id = get_query_var('order-pay');
 		$order = wc_get_order($order_id);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-gateway.php
@@ -473,6 +473,37 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 	}
 
 	/**
+	* Gets the necessary data to send to EBANX APIs.
+	*/
+	protected function get_data()
+	{
+		$data = array(
+			'ebanx_billing_brazil_person_type' => WC_EBANX_Request::read($this->names['ebanx_billing_brazil_person_type'], 'cpf'),
+			'ebanx_billing_brazil_document' => WC_EBANX_Request::read($this->names['ebanx_billing_brazil_document'], null),
+			'ebanx_billing_brazil_cnpj' => WC_EBANX_Request::read($this->names['ebanx_billing_brazil_cnpj'], null),
+			'ebanx_billing_brazil_birth_date' => WC_EBANX_Request::read($this->names['ebanx_billing_brazil_birth_date'], null),
+			'ebanx_billing_chile_document' => WC_EBANX_Request::read($this->names['ebanx_billing_chile_document'], null),
+			'ebanx_billing_chile_birth_date' => WC_EBANX_Request::read($this->names['ebanx_billing_chile_birth_date'], null),
+			'ebanx_billing_colombia_document' => WC_EBANX_Request::read($this->names['ebanx_billing_colombia_document'], null),
+			'billing_postcode' => WC_EBANX_Request::read('billing_postcode', null),
+			'billing_address_1' => WC_EBANX_Request::read('billing_address_1', null),
+			'billing_address_2' => WC_EBANX_Request::read('billing_address_2', null),
+			'billing_city' => WC_EBANX_Request::read('billing_city', null),
+			'billing_state' => WC_EBANX_Request::read('billing_state', null),
+			'billing_company' => WC_EBANX_Request::read('billing_company', null)
+		);
+
+		if ( !empty(WC_EBANX_Request::has($this->id)) ) {
+			$data = array_merge(
+				$data,
+				WC_EBANX_Request::read($this->id, array())
+			);
+		}
+
+		return $data;
+	}
+
+	/**
 	 * Mount the data to send to EBANX API
 	 *
 	 * @param  WC_Order $order
@@ -480,6 +511,8 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 	 */
 	protected function request_data($order)
 	{
+		$payload = $this->get_data();
+
 		$home_url = esc_url( home_url( '/' ) );
 
 		$has_cpf = false;
@@ -525,6 +558,7 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 
 		if ($this->getTransactionAddress('country') === WC_EBANX_Constants::COUNTRY_BRAZIL) {
 			$fields_options = array();
+
 			if (isset($this->configs->settings['brazil_taxes_options']) && is_array($this->configs->settings['brazil_taxes_options'])) {
 				$fields_options = $this->configs->settings['brazil_taxes_options'];
 			}
@@ -532,50 +566,50 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 			if (count($fields_options) === 1 && $fields_options[0] === 'cnpj') {
 				$person_type = 'business';
 			}
+
 			if (in_array('cpf', $fields_options) && in_array('cnpj', $fields_options)) {
-				$person_type = WC_EBANX_Request::read($this->names['ebanx_billing_brazil_person_type'], 'cpf') == 'cnpj' ? 'business' : 'personal';
+				$person_type = $payload['ebanx_billing_brazil_person_type'] == 'cnpj' ? 'business' : 'personal';
 			}
 
-
-			$has_cpf = !empty(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_document'], null));
-			$has_cnpj = !empty(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_cnpj'], null));
+			$has_cpf = !empty($payload['ebanx_billing_brazil_document']);
+			$has_cnpj = !empty($payload['ebanx_billing_brazil_cnpj']);
 
 			if (
-				empty(WC_EBANX_Request::read('billing_postcode', null)) ||
-				empty(WC_EBANX_Request::read('billing_address_1', null)) ||
-				empty(WC_EBANX_Request::read('billing_city', null)) ||
-				empty(WC_EBANX_Request::read('billing_state', null)) ||
-				($person_type == 'business' && (!$has_cnpj || empty(WC_EBANX_Request::read('billing_company', null)))) ||
+				empty($payload['billing_postcode']) ||
+				empty($payload['billing_address_1']) ||
+				empty($payload['billing_city']) ||
+				empty($payload['billing_state']) ||
+				($person_type == 'business' && (!$has_cnpj || empty($payload['billing_company']))) ||
 				($person_type == 'personal' && !$has_cpf)
 			) {
 				throw new Exception('INVALID-FIELDS');
 			}
 
 			if ($person_type == 'business') {
-				WC_EBANX_Request::set('ebanx_billing_document', WC_EBANX_Request::read($this->names['ebanx_billing_brazil_cnpj']));
+				WC_EBANX_Request::set('ebanx_billing_document', $payload['ebanx_billing_brazil_cnpj']);
 			} else {
-				WC_EBANX_Request::set('ebanx_billing_document', WC_EBANX_Request::read($this->names['ebanx_billing_brazil_document']));
-				WC_EBANX_Request::set('ebanx_billing_birth_date', WC_EBANX_Request::read($this->names['ebanx_billing_brazil_birth_date']));
+				WC_EBANX_Request::set('ebanx_billing_document', $payload['ebanx_billing_brazil_document']);
+				WC_EBANX_Request::set('ebanx_billing_birth_date', $payload['ebanx_billing_brazil_birth_date']);
 			}
 		}
 
 		if ($this->getTransactionAddress('country') === WC_EBANX_Constants::COUNTRY_CHILE) {
-			if (empty(WC_EBANX_Request::read($this->names['ebanx_billing_chile_document'], null)) || empty(WC_EBANX_Request::read($this->names['ebanx_billing_chile_birth_date'], null))) {
+			if ( empty($payload['ebanx_billing_chile_document']) || empty($payload['ebanx_billing_chile_birth_date']) ) {
 				throw new Exception('INVALID-FIELDS');
 			}
 
-			WC_EBANX_Request::set('ebanx_billing_document', WC_EBANX_Request::read($this->names['ebanx_billing_chile_document']));
-			WC_EBANX_Request::set('ebanx_billing_birth_date', WC_EBANX_Request::read($this->names['ebanx_billing_chile_birth_date']));
+			WC_EBANX_Request::set('ebanx_billing_document', $payload['ebanx_billing_chile_document']);
+			WC_EBANX_Request::set('ebanx_billing_birth_date', $payload['ebanx_billing_chile_birth_date']);
 		}
 
 		if ($this->getTransactionAddress('country') === WC_EBANX_Constants::COUNTRY_COLOMBIA) {
-			WC_EBANX_Request::set('ebanx_billing_document', WC_EBANX_Request::read($this->names['ebanx_billing_colombia_document']));
+			WC_EBANX_Request::set('ebanx_billing_document', $payload['ebanx_billing_colombia_document']);
 		}
 
-		$addresses = WC_EBANX_Request::read('billing_address_1');
+		$addresses = $payload['billing_address_1'];
 
-		if (!empty(WC_EBANX_Request::read('billing_address_2', null))) {
-			$addresses .= " - " . WC_EBANX_Request::read('billing_address_2');
+		if (!empty($payload['billing_address_2'])) {
+			$addresses .= " - " . $payload['billing_address_2'];
 		}
 
 		$addresses = WC_EBANX_Helper::split_street($addresses);
@@ -589,18 +623,18 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 		$newData['payment']['person_type'] = $person_type;
 
 		if (!empty(WC_EBANX_Request::read('ebanx_billing_document', null))) {
-			$newData['payment']['document'] = WC_EBANX_Request::read('ebanx_billing_document');
+			$newData['payment']['document'] = WC_EBANX_Request::read('ebanx_billing_document', null);
 		}
 
 		if (!empty(WC_EBANX_Request::read('ebanx_billing_birth_date', null))) {
-			$newData['payment']['birth_date'] = WC_EBANX_Request::read('ebanx_billing_birth_date');
+			$newData['payment']['birth_date'] = WC_EBANX_Request::read('ebanx_billing_birth_date', null);
 		}
 
-		if (!empty(WC_EBANX_Request::read('billing_postcode', null))) {
-			$newData['payment']['zipcode'] = WC_EBANX_Request::read('billing_postcode');
+		if (!empty($payload['billing_postcode'])) {
+			$newData['payment']['zipcode'] = $payload['billing_postcode'];
 		}
 
-		if (!empty(WC_EBANX_Request::read('billing_address_1', null))) {
+		if (!empty($payload['billing_address_1'])) {
 			$newData['payment']['address'] = $street_name;
 		}
 
@@ -608,12 +642,12 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 			$newData['payment']['street_number'] = $street_number;
 		}
 
-		if (!empty(WC_EBANX_Request::read('billing_city', null))) {
-			$newData['payment']['city'] = WC_EBANX_Request::read('billing_city');
+		if (!empty($payload['billing_city'])) {
+			$newData['payment']['city'] = $payload['billing_city'];
 		}
 
-		if (!empty(WC_EBANX_Request::read('billing_state', null))) {
-			$newData['payment']['state'] = WC_EBANX_Request::read('billing_state');
+		if (!empty($payload['billing_state'])) {
+			$newData['payment']['state'] = $payload['billing_state'];
 		}
 
 		if ($this->getTransactionAddress('country') === WC_EBANX_Constants::COUNTRY_BRAZIL) {
@@ -622,7 +656,7 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 				$newData['payment']['responsible'] = array(
 					"name" => $data['payment']['name']
 				);
-				$newData['payment']['name'] = WC_EBANX_Request::read('billing_company');
+				$newData['payment']['name'] = $payload['billing_company'];
 			}
 		}
 
@@ -797,17 +831,26 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 	protected function save_user_meta_fields($order)
 	{
 		if ($this->userId) {
+			$document = false;
+			$birthDate = false;
+
 			if (trim(strtolower($order->billing_country)) === WC_EBANX_Constants::COUNTRY_BRAZIL) {
 				if (WC_EBANX_Request::has($this->names['ebanx_billing_brazil_document'])) {
-					update_user_meta($this->userId, '_ebanx_billing_brazil_document', sanitize_text_field(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_document'])));
+					$document = sanitize_text_field(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_document']));
+
+					update_user_meta($this->userId, '_ebanx_billing_brazil_document', $document);
 				}
 
 				if (WC_EBANX_Request::has($this->names['ebanx_billing_brazil_birth_date'])) {
-					update_user_meta($this->userId, '_ebanx_billing_brazil_birth_date', sanitize_text_field(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_birth_date'])));
+					$birthDate = sanitize_text_field(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_birth_date']));
+
+					update_user_meta($this->userId, '_ebanx_billing_brazil_birth_date', $birthDate);
 				}
 
 				if (WC_EBANX_Request::has($this->names['ebanx_billing_brazil_cnpj'])) {
-					update_user_meta($this->userId, '_ebanx_billing_brazil_cnpj', sanitize_text_field(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_cnpj'])));
+					$document = sanitize_text_field(WC_EBANX_Request::read($this->names['ebanx_billing_brazil_cnpj']));
+
+					update_user_meta($this->userId, '_ebanx_billing_brazil_cnpj', $document);
 				}
 
 				if (WC_EBANX_Request::has($this->names['ebanx_billing_brazil_person_type'])) {
@@ -817,18 +860,32 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 
 			if (trim(strtolower($order->billing_country)) === WC_EBANX_Constants::COUNTRY_CHILE) {
 				if (WC_EBANX_Request::has('ebanx_billing_chile_document')) {
-					update_user_meta($this->userId, '_ebanx_billing_chile_document', sanitize_text_field(WC_EBANX_Request::read('ebanx_billing_chile_document')));
+					$document = sanitize_text_field(WC_EBANX_Request::read('ebanx_billing_chile_document'));
+
+					update_user_meta($this->userId, '_ebanx_billing_chile_document', $document);
 				}
 
 				if (WC_EBANX_Request::has('ebanx_billing_chile_birth_date')) {
-					update_user_meta($this->userId, '_ebanx_billing_chile_birth_date', sanitize_text_field(WC_EBANX_Request::read('ebanx_billing_chile_birth_date')));
+					$birthDate = sanitize_text_field(WC_EBANX_Request::read('ebanx_billing_chile_birth_date'));
+
+					update_user_meta($this->userId, '_ebanx_billing_chile_birth_date', $birthDate);
 				}
 			}
 
 			if ($this->getTransactionAddress('country') === WC_EBANX_Constants::COUNTRY_COLOMBIA) {
 				if (WC_EBANX_Request::has('ebanx_billing_colombia_document')) {
-					update_user_meta($this->userId, '_ebanx_billing_colombia_document', sanitize_text_field(WC_EBANX_Request::read('ebanx_billing_colombia_document')));
+					$document = sanitize_text_field(WC_EBANX_Request::read('ebanx_billing_colombia_document'));
+
+					update_user_meta($this->userId, '_ebanx_billing_colombia_document', $document);
 				}
+			}
+
+			if ($document !== false) {
+				update_user_meta($this->userId, '_ebanx_document', $document);
+			}
+
+			if ($birthDate !== false) {
+				update_user_meta($this->userId, '_ebanx_birth_date', $birthDate);
 			}
 		}
 	}
@@ -1040,8 +1097,6 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 	 * @return void
 	 */
 	public function checkout_rate_conversion($currency, $template = true, $country = null, $instalments = null) {
-		global $order;
-
 		if ( ! in_array($this->merchant_currency, WC_EBANX_Constants::$CURRENCIES_CODES_ALLOWED )
 			|| $this->configs->settings['show_local_amount'] !== 'yes') {
 			return;
@@ -1049,8 +1104,16 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway
 
 		$amount = WC()->cart->total;
 
-		if (!$amount) {
+		$order_id = null;
+
+		if (!empty(get_query_var('order-pay'))) {
 			$order_id = get_query_var('order-pay');
+		}
+		else if (WC_EBANX_Request::has('order_id') && !empty(WC_EBANX_Request::read('order_id', null))) {
+			$order_id = WC_EBANX_Request::read('order_id', null);
+		}
+
+		if (!is_null($order_id)) {
 			$order = new WC_Order($order_id);
 
 			$amount = $order->get_total();

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-oxxo-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-oxxo-gateway.php
@@ -54,7 +54,9 @@ class WC_EBANX_Oxxo_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'oxxo/payment-form.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-pagoefectivo-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-pagoefectivo-gateway.php
@@ -54,7 +54,9 @@ class WC_EBANX_Pagoefectivo_Gateway extends WC_EBANX_Gateway
 
 		wc_get_template(
 			'pagoefectivo/payment-form.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-safetypay-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-safetypay-gateway.php
@@ -76,6 +76,7 @@ class WC_EBANX_Safetypay_Gateway extends WC_EBANX_Redirect_Gateway
 			array(
 				'title'       => $this->title,
 				'description' => $this->description,
+				'id' => $this->id
 			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-sencillito-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-sencillito-gateway.php
@@ -68,7 +68,9 @@ class WC_EBANX_Sencillito_Gateway extends WC_EBANX_Redirect_Gateway
 
 		wc_get_template(
 			'sencillito/payment-form.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-servipag-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-servipag-gateway.php
@@ -54,7 +54,9 @@ class WC_EBANX_Servipag_Gateway extends WC_EBANX_Redirect_Gateway
 
 		wc_get_template(
 			'servipag/payment-form.php',
-			array(),
+			array(
+				'id' => $this->id
+			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()
 		);

--- a/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-tef-gateway.php
+++ b/woocommerce-gateway-ebanx/gateways/class-wc-ebanx-tef-gateway.php
@@ -57,6 +57,7 @@ class WC_EBANX_Tef_Gateway extends WC_EBANX_Redirect_Gateway
 			array(
 				'title'       => $this->title,
 				'description' => $this->description,
+				'id' => $this->id
 			),
 			'woocommerce/ebanx/',
 			WC_EBANX::get_templates_path()

--- a/woocommerce-gateway-ebanx/templates/account/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/account/payment-form.php
@@ -12,4 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-account" class="ebanx-payment-container ebanx-language-br"></div>
+<div id="ebanx-account" class="ebanx-payment-container ebanx-language-br">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-br.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/baloto/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/baloto/payment-form.php
@@ -11,4 +11,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-baloto-payment" class="ebanx-payment-container ebanx-language-es"></div>
+<div id="ebanx-baloto-payment" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-co.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/banking-ticket/checkout-instructions.php
+++ b/woocommerce-gateway-ebanx/templates/banking-ticket/checkout-instructions.php
@@ -12,4 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-banking-ticket" class="ebanx-payment-container ebanx-language-br"></div>
+<div id="ebanx-banking-ticket" class="ebanx-payment-container ebanx-language-br">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-br.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-br.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-br.php
@@ -1,0 +1,67 @@
+<?php
+	$order_id = get_query_var('order-pay');
+
+	if ($order_id) {
+		$order = wc_get_order($order_id);
+		$document = $order ? get_user_meta($order->get_user_id(), '_ebanx_document', true) : false;
+		$birthDate = $order ? get_user_meta($order->get_user_id(), '_ebanx_birth_date', true) : false;
+		$address = $order->get_address();
+
+		$fields = array(
+			'ebanx_billing_brazil_document' => array(
+				'label' => 'CPF',
+				'value' => $document
+			),
+			'ebanx_billing_brazil_birth_date' => array(
+				'label' => __('Birth Date', 'woocommerce-gateway-ebanx'),
+				'value' => $birthDate
+			),
+			'billing_postcode' => array(
+				'label' => __('Zipcode', 'woocommerce'),
+				'value' => $address['postcode']
+			),
+			'billing_address_1' => array(
+				'label' => 'Address',
+				'value' => $address['address_1']
+			),
+			'billing_city' => array(
+				'label' => 'City',
+				'value' => $address['city']
+			),
+			'billing_state' => array(
+				'label' => 'State',
+				'value' => $address['state']
+			),
+			'billing_country' => array(
+				'label' => 'Country',
+				'value' => $address['country'],
+				'type' => 'hidden'
+			)
+		);
+	}
+?>
+
+<?php if ($order_id): ?>
+	<div class="ebanx-compliance-fields ebanx-compliance-fiels-br">
+		<?php foreach ($fields as $name => $field): ?>
+			<?php if (isset($field['type']) && $field['type'] === 'hidden'): ?>
+				<input
+					type="hidden"
+					name="<?php echo "{$id}[{$name}]" ?>"
+					value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+					class="input-text"
+				/>
+			<?php else: ?>
+				<label>
+					<?php echo $field['label'] ?>
+					<input
+						type="<?php echo isset($field['type']) ? $field['type'] : 'text'  ?>"
+						name="<?php echo "{$id}[{$name}]" ?>"
+						value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+						class="input-text"
+					/>
+				</label>
+			<?php endif ?>
+		<?php endforeach ?>
+	</div>
+<?php endif ?>

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-br.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-br.php
@@ -17,23 +17,22 @@
 				'value' => $birthDate
 			),
 			'billing_postcode' => array(
-				'label' => __('Zipcode', 'woocommerce'),
+				'label' => __('Postcode / ZIP', 'woocommerce'),
 				'value' => $address['postcode']
 			),
 			'billing_address_1' => array(
-				'label' => 'Address',
+				'label' => __('Street address', 'woocommerce'),
 				'value' => $address['address_1']
 			),
 			'billing_city' => array(
-				'label' => 'City',
+				'label' => __('Town / City', 'woocommerce'),
 				'value' => $address['city']
 			),
 			'billing_state' => array(
-				'label' => 'State',
+				'label' => __('State / County', 'woocommerce'),
 				'value' => $address['state']
 			),
 			'billing_country' => array(
-				'label' => 'Country',
 				'value' => $address['country'],
 				'type' => 'hidden'
 			)

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-cl.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-cl.php
@@ -1,0 +1,67 @@
+<?php
+	$order_id = get_query_var('order-pay');
+
+	if ($order_id) {
+		$order = wc_get_order($order_id);
+		$document = $order ? get_user_meta($order->get_user_id(), '_ebanx_document', true) : false;
+		$birthDate = $order ? get_user_meta($order->get_user_id(), '_ebanx_birth_date', true) : false;
+		$address = $order->get_address();
+
+		$fields = array(
+			'ebanx_billing_chile_document' => array(
+				'label' => 'RUT',
+				'value' => $document
+			),
+			'ebanx_billing_chile_birth_date' => array(
+				'label' => __('Birth Date', 'woocommerce-gateway-ebanx'),
+				'value' => $birthDate
+			),
+			'billing_postcode' => array(
+				'label' => __('Zipcode', 'woocommerce'),
+				'value' => $address['postcode']
+			),
+			'billing_address_1' => array(
+				'label' => 'Address',
+				'value' => $address['address_1']
+			),
+			'billing_city' => array(
+				'label' => 'City',
+				'value' => $address['city']
+			),
+			'billing_state' => array(
+				'label' => 'State',
+				'value' => $address['state']
+			),
+			'billing_country' => array(
+				'label' => 'Country',
+				'value' => $address['country'],
+				'type' => 'hidden'
+			)
+		);
+	}
+?>
+
+<?php if ($order_id): ?>
+	<div class="ebanx-compliance-fields ebanx-compliance-fiels-cl">
+		<?php foreach ($fields as $name => $field): ?>
+			<?php if (isset($field['type']) && $field['type'] === 'hidden'): ?>
+				<input
+					type="hidden"
+					name="<?php echo "{$id}[{$name}]" ?>"
+					value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+					class="input-text"
+				/>
+			<?php else: ?>
+				<label>
+					<?php echo $field['label'] ?>
+					<input
+						type="<?php echo isset($field['type']) ? $field['type'] : 'text'  ?>"
+						name="<?php echo "{$id}[{$name}]" ?>"
+						value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+						class="input-text"
+					/>
+				</label>
+			<?php endif ?>
+		<?php endforeach ?>
+	</div>
+<?php endif ?>

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-cl.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-cl.php
@@ -17,19 +17,19 @@
 				'value' => $birthDate
 			),
 			'billing_postcode' => array(
-				'label' => __('Zipcode', 'woocommerce'),
+				'label' => __('Postcode / ZIP', 'woocommerce'),
 				'value' => $address['postcode']
 			),
 			'billing_address_1' => array(
-				'label' => 'Address',
+				'label' => __('Street address', 'woocommerce'),
 				'value' => $address['address_1']
 			),
 			'billing_city' => array(
-				'label' => 'City',
+				'label' => __('Town / City', 'woocommerce'),
 				'value' => $address['city']
 			),
 			'billing_state' => array(
-				'label' => 'State',
+				'label' => __('State / County', 'woocommerce'),
 				'value' => $address['state']
 			),
 			'billing_country' => array(

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-co.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-co.php
@@ -1,0 +1,62 @@
+<?php
+	$order_id = get_query_var('order-pay');
+
+	if ($order_id) {
+		$order = wc_get_order($order_id);
+		$document = $order ? get_user_meta($order->get_user_id(), '_ebanx_document', true) : false;
+		$address = $order->get_address();
+
+		$fields = array(
+			'ebanx_billing_colombia_document' => array(
+				'label' => 'DNI',
+				'value' => $document
+			),
+			'billing_postcode' => array(
+				'label' => __('Zipcode', 'woocommerce'),
+				'value' => $address['postcode']
+			),
+			'billing_address_1' => array(
+				'label' => 'Address',
+				'value' => $address['address_1']
+			),
+			'billing_city' => array(
+				'label' => 'City',
+				'value' => $address['city']
+			),
+			'billing_state' => array(
+				'label' => 'State',
+				'value' => $address['state']
+			),
+			'billing_country' => array(
+				'label' => 'Country',
+				'value' => $address['country'],
+				'type' => 'hidden'
+			)
+		);
+	}
+?>
+
+<?php if ($order_id): ?>
+	<div class="ebanx-compliance-fields ebanx-compliance-fiels-co">
+		<?php foreach ($fields as $name => $field): ?>
+			<?php if (isset($field['type']) && $field['type'] === 'hidden'): ?>
+				<input
+					type="hidden"
+					name="<?php echo "{$id}[{$name}]" ?>"
+					value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+					class="input-text"
+				/>
+			<?php else: ?>
+				<label>
+					<?php echo $field['label'] ?>
+					<input
+						type="<?php echo isset($field['type']) ? $field['type'] : 'text'  ?>"
+						name="<?php echo "{$id}[{$name}]" ?>"
+						value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+						class="input-text"
+					/>
+				</label>
+			<?php endif ?>
+		<?php endforeach ?>
+	</div>
+<?php endif ?>

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-co.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-co.php
@@ -12,19 +12,19 @@
 				'value' => $document
 			),
 			'billing_postcode' => array(
-				'label' => __('Zipcode', 'woocommerce'),
+				'label' => __('Postcode / ZIP', 'woocommerce'),
 				'value' => $address['postcode']
 			),
 			'billing_address_1' => array(
-				'label' => 'Address',
+				'label' => __('Street address', 'woocommerce'),
 				'value' => $address['address_1']
 			),
 			'billing_city' => array(
-				'label' => 'City',
+				'label' => __('Town / City', 'woocommerce'),
 				'value' => $address['city']
 			),
 			'billing_state' => array(
-				'label' => 'State',
+				'label' => __('State / County', 'woocommerce'),
 				'value' => $address['state']
 			),
 			'billing_country' => array(

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-mx.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-mx.php
@@ -7,19 +7,19 @@
 
 		$fields = array(
 			'billing_postcode' => array(
-				'label' => __('Zipcode', 'woocommerce'),
+				'label' => __('Postcode / ZIP', 'woocommerce'),
 				'value' => $address['postcode']
 			),
 			'billing_address_1' => array(
-				'label' => 'Address',
+				'label' => __('Street address', 'woocommerce'),
 				'value' => $address['address_1']
 			),
 			'billing_city' => array(
-				'label' => 'City',
+				'label' => __('Town / City', 'woocommerce'),
 				'value' => $address['city']
 			),
 			'billing_state' => array(
-				'label' => 'State',
+				'label' => __('State / County', 'woocommerce'),
 				'value' => $address['state']
 			),
 			'billing_country' => array(

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-mx.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-mx.php
@@ -1,0 +1,57 @@
+<?php
+	$order_id = get_query_var('order-pay');
+
+	if ($order_id) {
+		$order = wc_get_order($order_id);
+		$address = $order->get_address();
+
+		$fields = array(
+			'billing_postcode' => array(
+				'label' => __('Zipcode', 'woocommerce'),
+				'value' => $address['postcode']
+			),
+			'billing_address_1' => array(
+				'label' => 'Address',
+				'value' => $address['address_1']
+			),
+			'billing_city' => array(
+				'label' => 'City',
+				'value' => $address['city']
+			),
+			'billing_state' => array(
+				'label' => 'State',
+				'value' => $address['state']
+			),
+			'billing_country' => array(
+				'label' => 'Country',
+				'value' => $address['country'],
+				'type' => 'hidden'
+			)
+		);
+	}
+?>
+
+<?php if ($order_id): ?>
+	<div class="ebanx-compliance-fields ebanx-compliance-fiels-mx">
+		<?php foreach ($fields as $name => $field): ?>
+			<?php if (isset($field['type']) && $field['type'] === 'hidden'): ?>
+				<input
+					type="hidden"
+					name="<?php echo "{$id}[{$name}]" ?>"
+					value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+					class="input-text"
+				/>
+			<?php else: ?>
+				<label>
+					<?php echo $field['label'] ?>
+					<input
+						type="<?php echo isset($field['type']) ? $field['type'] : 'text'  ?>"
+						name="<?php echo "{$id}[{$name}]" ?>"
+						value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+						class="input-text"
+					/>
+				</label>
+			<?php endif ?>
+		<?php endforeach ?>
+	</div>
+<?php endif ?>

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-pe.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-pe.php
@@ -7,19 +7,19 @@
 
 		$fields = array(
 			'billing_postcode' => array(
-				'label' => __('Zipcode', 'woocommerce'),
+				'label' => __('Postcode / ZIP', 'woocommerce'),
 				'value' => $address['postcode']
 			),
 			'billing_address_1' => array(
-				'label' => 'Address',
+				'label' => __('Street address', 'woocommerce'),
 				'value' => $address['address_1']
 			),
 			'billing_city' => array(
-				'label' => 'City',
+				'label' => __('Town / City', 'woocommerce'),
 				'value' => $address['city']
 			),
 			'billing_state' => array(
-				'label' => 'State',
+				'label' => __('State / County', 'woocommerce'),
 				'value' => $address['state']
 			),
 			'billing_country' => array(

--- a/woocommerce-gateway-ebanx/templates/compliance-fields-pe.php
+++ b/woocommerce-gateway-ebanx/templates/compliance-fields-pe.php
@@ -1,0 +1,57 @@
+<?php
+	$order_id = get_query_var('order-pay');
+
+	if ($order_id) {
+		$order = wc_get_order($order_id);
+		$address = $order->get_address();
+
+		$fields = array(
+			'billing_postcode' => array(
+				'label' => __('Zipcode', 'woocommerce'),
+				'value' => $address['postcode']
+			),
+			'billing_address_1' => array(
+				'label' => 'Address',
+				'value' => $address['address_1']
+			),
+			'billing_city' => array(
+				'label' => 'City',
+				'value' => $address['city']
+			),
+			'billing_state' => array(
+				'label' => 'State',
+				'value' => $address['state']
+			),
+			'billing_country' => array(
+				'label' => 'Country',
+				'value' => $address['country'],
+				'type' => 'hidden'
+			)
+		);
+	}
+?>
+
+<?php if ($order_id): ?>
+	<div class="ebanx-compliance-fields ebanx-compliance-fiels-pe">
+		<?php foreach ($fields as $name => $field): ?>
+			<?php if (isset($field['type']) && $field['type'] === 'hidden'): ?>
+				<input
+					type="hidden"
+					name="<?php echo "{$id}[{$name}]" ?>"
+					value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+					class="input-text"
+				/>
+			<?php else: ?>
+				<label>
+					<?php echo $field['label'] ?>
+					<input
+						type="<?php echo isset($field['type']) ? $field['type'] : 'text'  ?>"
+						name="<?php echo "{$id}[{$name}]" ?>"
+						value="<?php echo isset($field['value']) ? $field['value'] : null  ?>"
+						class="input-text"
+					/>
+				</label>
+			<?php endif ?>
+		<?php endforeach ?>
+	</div>
+<?php endif ?>

--- a/woocommerce-gateway-ebanx/templates/debit-card/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/debit-card/payment-form.php
@@ -6,6 +6,8 @@ if (!defined('ABSPATH')) {
 ?>
 
 <div id="ebanx-debit-cart-form" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-mx.php' ?>
+
 	<div id="ebanx-container-new-debit-card">
 		<section class="ebanx-form-row">
 			<label for="ebanx-debit-card-holder-name"><?php _e('Titular de la tarjeta', 'woocommerce-gateway-ebanx') ?> <span class="required">*</span></label>

--- a/woocommerce-gateway-ebanx/templates/ebanx-credit-card-br/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/ebanx-credit-card-br/payment-form.php
@@ -13,6 +13,8 @@ if (!defined('ABSPATH')) {
 ?>
 
 <div id="ebanx-credit-cart-form" class="ebanx-payment-container ebanx-language-br">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-br.php' ?>
+
     <section class="ebanx-form-row">
     	<?php if (!empty($cards)): ?>
     		<?php foreach ($cards as $k => $card): ?>

--- a/woocommerce-gateway-ebanx/templates/ebanx-credit-card-mx/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/ebanx-credit-card-mx/payment-form.php
@@ -13,6 +13,8 @@ if (!defined('ABSPATH')) {
 ?>
 
 <div id="ebanx-credit-cart-form" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-mx.php' ?>
+
     <section class="ebanx-form-row">
     	<?php if (!empty($cards)): ?>
     		<?php foreach ($cards as $k => $card): ?>

--- a/woocommerce-gateway-ebanx/templates/eft/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/eft/payment-form.php
@@ -15,6 +15,8 @@ asort($banks);
 ?>
 
 <div id="ebanx-eft-payment" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-co.php' ?>
+
     <select name="eft" class="ebanx-select-field">
         <?php foreach($banks as $key => $bank): ?>
         	<option value="<?php echo $key ?>"><?php echo $bank ?></option>

--- a/woocommerce-gateway-ebanx/templates/instalments.php
+++ b/woocommerce-gateway-ebanx/templates/instalments.php
@@ -2,7 +2,14 @@
 <?php if ( count($instalments_terms) > 1 ) : ?>
 	<section class="ebanx-form-row">
 		<label for="ebanx-card-installments"><?php echo $instalments; ?> <span class="required">*</span></label>
-		<select data-country="<?php echo $country ?>" data-amount="<?php echo $cart_total ?>" data-currency="<?php echo $currency ?>" class="ebanx-instalments ebanx-select-field" name="ebanx-credit-card-installments">
+		<select
+			data-country="<?php echo $country ?>"
+			data-amount="<?php echo $cart_total ?>"
+			data-currency="<?php echo $currency ?>"
+			data-order-id="<?php echo get_query_var('order-pay') ?>"
+			class="ebanx-instalments ebanx-select-field"
+			name="ebanx-credit-card-installments"
+		>
 			<?php foreach ($instalments_terms as $instalment): ?>
 				<option value="<?php echo $instalment['number'] ?>">
 					<?php printf( __( '%1$dx of %2$s', 'woocommerce-gateway-ebanx' ), absint( $instalment['number'] ), esc_html( strip_tags( wc_price( $instalment['price'] ) ) ) ); ?>

--- a/woocommerce-gateway-ebanx/templates/oxxo/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/oxxo/payment-form.php
@@ -12,4 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-oxxo-payment" class="ebanx-payment-container ebanx-language-es"></div>
+<div id="ebanx-oxxo-payment" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-mx.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/pagoefectivo/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/pagoefectivo/payment-form.php
@@ -12,4 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-pagoefectivo-payment" class="ebanx-payment-container ebanx-language-es"></div>
+<div id="ebanx-pagoefectivo-payment" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-pe.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/safetypay/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/safetypay/payment-form.php
@@ -13,7 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div id="ebanx-safetypay-payment" class="ebanx-payment-container ebanx-language-es">
-  <div class="ebanx-form-row">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-pe.php' ?>
+
+  	<div class="ebanx-form-row">
 		<label class="ebanx-label">
 			<input type="radio" name="safetypay" value="cash" checked> Cash
 		</label>

--- a/woocommerce-gateway-ebanx/templates/sencillito/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/sencillito/payment-form.php
@@ -12,4 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-sencillito" class="ebanx-payment-container ebanx-language-es"></div>
+<div id="ebanx-sencillito" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-cl.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/servipag/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/servipag/payment-form.php
@@ -12,4 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<div id="ebanx-servipag-payment" class="ebanx-payment-container ebanx-language-es"></div>
+<div id="ebanx-servipag-payment" class="ebanx-payment-container ebanx-language-es">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-cl.php' ?>
+</div>

--- a/woocommerce-gateway-ebanx/templates/tef/payment-form.php
+++ b/woocommerce-gateway-ebanx/templates/tef/payment-form.php
@@ -13,6 +13,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 
 <div id="ebanx-tef-payment" class="ebanx-payment-container ebanx-language-br">
+	<?php include WC_EBANX::get_templates_path() . 'compliance-fields-br.php' ?>
+
 	<p>
 		<label class="ebanx-label">
 			<input type="radio" name="tef" value="itau" checked> Itaú

--- a/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx/woocommerce-gateway-ebanx.php
@@ -587,7 +587,7 @@ if ( ! class_exists('WC_EBANX') ) {
 			$configs = new WC_EBANX_Global_Gateway();
 
 			if ($configs->settings['debug_enabled'] !== 'yes') return;
-			
+
 			if (empty(self::$log)) self::$log = new WC_Logger();
 
 			self::$log->add('woocommerce-gateway-ebanx', $message);


### PR DESCRIPTION
This is a huge feature enabling the pay for oder woocommerce page.

This page can be created by the merchants and are sent to the customer. It's a custom page to customers pay their orders without the necessity to fill a checkout page.

To test it, follow the steps:
* WooCommerce > Orders
* Add Order
* Select a customer or fill the billing fields
* Set a order price or a product
* Create it
* Click on the right link from "Order status"