### PR TITLE
Fix PHP Strict Standards issue on WC_EBANX_Logger

### DIFF
--- a/services/loggers/class-wc-ebanx-logger.php
+++ b/services/loggers/class-wc-ebanx-logger.php
@@ -24,11 +24,13 @@ abstract class WC_EBANX_Logger {
 	}
 
 	/**
-	 * Abstract method that must be overrated by child classes
+	 * This method should be reimplemented by child classes
 	 *
 	 * This method is responsible for receive log data, manage them and send them to method save
 	 *
 	 * @param array $log_data data to be logged.
 	 */
-	abstract public static function persist( array $log_data = [] );
+	public static function persist( array $log_data = [] ) {
+		throw new Exception( 'Logger child classes must reimplemented the persist function. See class-wc-ebanx-logger.php' );
+	}
 }

--- a/services/loggers/class-wc-ebanx-logger.php
+++ b/services/loggers/class-wc-ebanx-logger.php
@@ -29,7 +29,7 @@ abstract class WC_EBANX_Logger {
 	 * This method is responsible for receive log data, manage them and send them to method save
 	 *
 	 * @param array $log_data data to be logged.
-	 * @Throws Exception in case sub classes do not reimplement.
+	 * @throws Exception in case sub classes do not reimplement.
 	 */
 	public static function persist( array $log_data = [] ) {
 		throw new Exception( 'Logger child classes must reimplemented the persist function. See class-wc-ebanx-logger.php' );

--- a/services/loggers/class-wc-ebanx-logger.php
+++ b/services/loggers/class-wc-ebanx-logger.php
@@ -29,7 +29,7 @@ abstract class WC_EBANX_Logger {
 	 * This method is responsible for receive log data, manage them and send them to method save
 	 *
 	 * @param array $log_data data to be logged.
-	 * @throws exception in case sub classes do not reimplement
+	 * @Throws Exception in case sub classes do not reimplement.
 	 */
 	public static function persist( array $log_data = [] ) {
 		throw new Exception( 'Logger child classes must reimplemented the persist function. See class-wc-ebanx-logger.php' );

--- a/services/loggers/class-wc-ebanx-logger.php
+++ b/services/loggers/class-wc-ebanx-logger.php
@@ -29,7 +29,7 @@ abstract class WC_EBANX_Logger {
 	 * This method is responsible for receive log data, manage them and send them to method save
 	 *
 	 * @param array $log_data data to be logged.
-	 * @throws Exception in case sub classes do not reimplement.
+	 * @throws Exception In case sub classes do not reimplement an exception is thrown.
 	 */
 	public static function persist( array $log_data = [] ) {
 		throw new Exception( 'Logger child classes must reimplemented the persist function. See class-wc-ebanx-logger.php' );

--- a/services/loggers/class-wc-ebanx-logger.php
+++ b/services/loggers/class-wc-ebanx-logger.php
@@ -29,6 +29,7 @@ abstract class WC_EBANX_Logger {
 	 * This method is responsible for receive log data, manage them and send them to method save
 	 *
 	 * @param array $log_data data to be logged.
+	 * @throws exception in case sub classes do not reimplement
 	 */
 	public static function persist( array $log_data = [] ) {
 		throw new Exception( 'Logger child classes must reimplemented the persist function. See class-wc-ebanx-logger.php' );


### PR DESCRIPTION
This fixes error `Strict Standards: Static function WC_EBANX_Logger::persist() should not be abstract in` that happens because a method should not be both abstract and static.