### PR TITLE
Remove require command from WC_EBANX_Payment_Validator and start use a namespace

### DIFF
--- a/lib/Plugin/Services/WC_EBANX_Payment_Validator.php
+++ b/lib/Plugin/Services/WC_EBANX_Payment_Validator.php
@@ -1,14 +1,7 @@
 <?php
 
-use EBANX\Plugin\Services\WC_EBANX_Constants;
+namespace EBANX\Plugin\Services;
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-/**
- * Class WC_EBANX_Payment_Validator
- */
 class WC_EBANX_Payment_Validator {
 
 	/**

--- a/services/class-wc-ebanx-payment-by-link.php
+++ b/services/class-wc-ebanx-payment-by-link.php
@@ -5,6 +5,7 @@ use Ebanx\Benjamin\Models\Country;
 use Ebanx\Benjamin\Models\Person;
 use Ebanx\Benjamin\Models\Request;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Validator;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -685,7 +685,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 
 			// Hooks/Actions.
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-payment-by-link.php';
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-payment-validator.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-my-account.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-one-click.php';
 


### PR DESCRIPTION
This PR change WC_EBANX_Payment_Validator move from `services` folder to `lib/Plugin/Services` folder and add the namespace `EBANX\Plugin\Services`.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Payment_Validator in the project.