### PR TITLE
Remove require command from WC_EBANX_Errors and start use a namespace

### DIFF
--- a/gateways/class-wc-ebanx-new-gateway.php
+++ b/gateways/class-wc-ebanx-new-gateway.php
@@ -4,6 +4,7 @@ use Ebanx\Benjamin\Models\Configs\CreditCardConfig;
 use Ebanx\Benjamin\Models\Country;
 use Ebanx\Benjamin\Models\Currency;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Errors;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/lib/Plugin/Services/WC_EBANX_Errors.php
+++ b/lib/Plugin/Services/WC_EBANX_Errors.php
@@ -1,8 +1,7 @@
 <?php
 
-/**
- * Class WC_EBANX_Errors
- */
+namespace EBANX\Plugin\Services;
+
 class WC_EBANX_Errors {
 	/**
 	 * The possible errors that EBANX can throw

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -630,7 +630,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-checker.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-flash.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-request.php';
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-errors.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-assets.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-third-party-compability-layer.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-cancel-order.php';


### PR DESCRIPTION
This PR change WC_EBANX_Errors move from `services` folder to `lib/Plugin/Services` folder and add the namespace `EBANX\Plugin\Services`.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Errors in the project.