### PR TITLE
Remove require command from WC_EBANX_Helper and start use a namespace

### DIFF
--- a/controllers/class-wc-ebanx-api-controller.php
+++ b/controllers/class-wc-ebanx-api-controller.php
@@ -5,6 +5,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 /**
  * Class WC_EBANX_Api_Controller

--- a/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -3,6 +3,7 @@
 use Ebanx\Benjamin\Models\Configs\CreditCardConfig;
 use Ebanx\Benjamin\Models\Country;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/gateways/class-wc-ebanx-gateway.php
+++ b/gateways/class-wc-ebanx-gateway.php
@@ -1,6 +1,7 @@
 <?php
 
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/gateways/class-wc-ebanx-global-gateway.php
+++ b/gateways/class-wc-ebanx-global-gateway.php
@@ -9,11 +9,11 @@ if ( ! defined( 'IS_TEST' ) ) {
 	if ( ! in_array( 'woocommerce/woocommerce.php', $active_plugins ) ) {
 		wp_die( 'Sorry, but this plugin requires the Woocommerce plugin to be installed and active.', null, array( 'back_link' => true ) );
 	}
-	require_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-helper.php';
 }
 
 use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Notice;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 /**
  * Class WC_EBANX_Global_Gateway

--- a/gateways/class-wc-ebanx-new-gateway.php
+++ b/gateways/class-wc-ebanx-new-gateway.php
@@ -5,6 +5,7 @@ use Ebanx\Benjamin\Models\Country;
 use Ebanx\Benjamin\Models\Currency;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Errors;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/lib/Plugin/Services/WC_EBANX_Helper.php
+++ b/lib/Plugin/Services/WC_EBANX_Helper.php
@@ -1,23 +1,20 @@
 <?php
 
+namespace EBANX\Plugin\Services;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
 if ( ! defined( 'IS_TEST' ) ) {
 	require_once WC_EBANX_GATEWAYS_DIR . 'class-wc-ebanx-global-gateway.php';
-	require_once WC_EBANX_VENDOR_DIR . 'autoload.php';
 }
 
 use RuntimeException as RuntimeException;
 use Ebanx\Benjamin\Services\Gateways\CreditCard;
 use Ebanx\Benjamin\Models\Configs\Config;
 use Ebanx\Benjamin\Models\Configs\CreditCardConfig;
-use EBANX\Plugin\Services\WC_EBANX_Constants;
 
-/**
- * Class WC_EBANX_Helper
- */
 abstract class WC_EBANX_Helper {
 
 	/**
@@ -30,8 +27,8 @@ abstract class WC_EBANX_Helper {
 		$return = array();
 		array_walk_recursive(
 			$array, function( $value ) use ( &$return ) {
-				$return[] = $value;
-			}
+			$return[] = $value;
+		}
 		);
 
 		return $return;
@@ -43,7 +40,7 @@ abstract class WC_EBANX_Helper {
 	 * @return string
 	 */
 	public static function get_integration_key() {
-		$config = new WC_EBANX_Global_Gateway();
+		$config = new \WC_EBANX_Global_Gateway();
 
 		return 'yes' === $config->settings['sandbox_mode_enabled'] ? $config->settings['sandbox_private_key'] : $config->settings['live_private_key'];
 	}
@@ -169,7 +166,7 @@ abstract class WC_EBANX_Helper {
 	 * @return bool
 	 */
 	public static function should_apply_taxes() {
-		$configs = new WC_EBANX_Global_Gateway();
+		$configs = new \WC_EBANX_Global_Gateway();
 
 		return $configs->get_setting_or_default( 'add_iof_to_local_amount_enabled', 'yes' ) === 'yes';
 	}
@@ -179,7 +176,7 @@ abstract class WC_EBANX_Helper {
 	 *
 	 * @return array
 	 */
-	public static function plugin_check( WC_EBANX_Global_Gateway $configs ) {
+	public static function plugin_check( \WC_EBANX_Global_Gateway $configs ) {
 		global $wpdb;
 
 		$all_plugins   = get_plugins();

--- a/services/class-wc-ebanx-payment-adapter.php
+++ b/services/class-wc-ebanx-payment-adapter.php
@@ -7,6 +7,7 @@ use Ebanx\Benjamin\Models\Item;
 use Ebanx\Benjamin\Models\Payment;
 use Ebanx\Benjamin\Models\Person;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 /**
  * Class WC_EBANX_Payment_Adapter

--- a/services/loggers/class-wc-ebanx-logger.php
+++ b/services/loggers/class-wc-ebanx-logger.php
@@ -1,6 +1,6 @@
 <?php
 
-require_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-helper.php';
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 /**
  * Abstract logger class, responsible to persist log on database

--- a/templates/ebanx-credit-card-ar/card-template.php
+++ b/templates/ebanx-credit-card-ar/card-template.php
@@ -21,7 +21,7 @@
 				<?php
 				$input_type     = 'checkbox';
 				$save_card_text = 'Guarda esta tarjeta para compras futuras.';
-				if ( WC_EBANX_Helper::checkout_contains_subscription() ) {
+				if ( EBANX\Plugin\Services\WC_EBANX_Helper::checkout_contains_subscription() ) {
 					$input_type     = 'hidden';
 					$save_card_text = null;
 				}

--- a/templates/ebanx-credit-card-br/card-template.php
+++ b/templates/ebanx-credit-card-br/card-template.php
@@ -21,7 +21,7 @@
 				<?php
 				$input_type     = 'checkbox';
 				$save_card_text = 'Salvar este cartão para compras futuras';
-				if ( WC_EBANX_Helper::checkout_contains_subscription() ) {
+				if ( EBANX\Plugin\Services\WC_EBANX_Helper::checkout_contains_subscription() ) {
 					$input_type     = 'hidden';
 					$save_card_text = null;
 				}

--- a/templates/ebanx-credit-card-co/card-template.php
+++ b/templates/ebanx-credit-card-co/card-template.php
@@ -26,7 +26,7 @@
 				<?php
 				$input_type     = 'checkbox';
 				$save_card_text = 'Guarda esta tarjeta para compras futuras.';
-				if ( WC_EBANX_Helper::checkout_contains_subscription() ) {
+				if ( EBANX\Plugin\Services\WC_EBANX_Helper::checkout_contains_subscription() ) {
 					$input_type     = 'hidden';
 					$save_card_text = null;
 				}

--- a/templates/ebanx-credit-card-mx/card-template.php
+++ b/templates/ebanx-credit-card-mx/card-template.php
@@ -26,7 +26,7 @@
 				<?php
 				$input_type     = 'checkbox';
 				$save_card_text = 'Guarda esta tarjeta para compras futuras.';
-				if ( WC_EBANX_Helper::checkout_contains_subscription() ) {
+				if ( EBANX\Plugin\Services\WC_EBANX_Helper::checkout_contains_subscription() ) {
 					$input_type     = 'hidden';
 					$save_card_text = null;
 				}

--- a/templates/instalments.php
+++ b/templates/instalments.php
@@ -5,7 +5,7 @@ $currency_rate = $currency_rate ?: 1;
 
 if ( count( $instalments_terms ) > 1 ) : ?>
 	<section class="ebanx-form-row">
-		<?php if ( WC_EBANX_Helper::checkout_contains_subscription() ) : ?>
+		<?php if ( EBANX\Plugin\Services\WC_EBANX_Helper::checkout_contains_subscription() ) : ?>
 			<input type="hidden" name="ebanx-credit-card-installments" value="1" />
 		<?php else : ?>
 			<label for="ebanx-card-installments">

--- a/tests/unit/services/EbanxHelperTest.php
+++ b/tests/unit/services/EbanxHelperTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
+use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 class EbanxHelperTest extends TestCase {
 	public function setUp() {

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -625,7 +625,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 		 */
 		private function includes() {
 			// Utils.
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-helper.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-hooks.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-checker.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-flash.php';


### PR DESCRIPTION
This PR change WC_EBANX_Helper move from `services` folder to `lib/Plugin/Services` folder and add the namespace `EBANX\Plugin\Services`.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Helper in the project.