### PR TITLE
Remove require command from WC_EBANX_Payment_Adapter and start use a namespace

### DIFF
--- a/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -9,6 +9,7 @@ use Ebanx\Benjamin\Models\Country;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Helper;
 use EBANX\Plugin\Services\WC_EBANX_Api;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 
 /**
  * Class WC_EBANX_Credit_Card_Gateway

--- a/gateways/class-wc-ebanx-debit-card-gateway.php
+++ b/gateways/class-wc-ebanx-debit-card-gateway.php
@@ -2,6 +2,7 @@
 
 use Ebanx\Benjamin\Models\Country;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/gateways/class-wc-ebanx-efectivo-gateway.php
+++ b/gateways/class-wc-ebanx-efectivo-gateway.php
@@ -2,6 +2,7 @@
 
 use Ebanx\Benjamin\Models\Country;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/gateways/class-wc-ebanx-eft-gateway.php
+++ b/gateways/class-wc-ebanx-eft-gateway.php
@@ -2,6 +2,7 @@
 
 use Ebanx\Benjamin\Models\Country;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/gateways/class-wc-ebanx-new-gateway.php
+++ b/gateways/class-wc-ebanx-new-gateway.php
@@ -11,6 +11,7 @@ use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Errors;
 use EBANX\Plugin\Services\WC_EBANX_Helper;
 use EBANX\Plugin\Services\WC_EBANX_Api;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 
 /**
  * Class WC_EBANX_New_Gateway
@@ -230,7 +231,7 @@ class WC_EBANX_New_Gateway extends WC_EBANX_Gateway {
 					'redirect' => $this->get_return_url( $order ),
 				]
 			);
-		} catch ( Exception $e ) {
+		} catch ( \Exception $e ) {
 			$country = $this->get_transaction_address( 'country' );
 
 			$message = WC_EBANX_Errors::get_error_message( $e, $country );

--- a/gateways/class-wc-ebanx-safetypay-gateway.php
+++ b/gateways/class-wc-ebanx-safetypay-gateway.php
@@ -2,6 +2,7 @@
 
 use Ebanx\Benjamin\Models\Country;
 use EBANX\Plugin\Services\WC_EBANX_Constants;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/lib/Plugin/Services/WC_EBANX_Payment_Adapter.php
+++ b/lib/Plugin/Services/WC_EBANX_Payment_Adapter.php
@@ -1,13 +1,13 @@
 <?php
 
+namespace EBANX\Plugin\Services;
+
 use Ebanx\Benjamin\Models\Address;
 use Ebanx\Benjamin\Models\Card;
 use Ebanx\Benjamin\Models\Country;
 use Ebanx\Benjamin\Models\Item;
 use Ebanx\Benjamin\Models\Payment;
 use Ebanx\Benjamin\Models\Person;
-use EBANX\Plugin\Services\WC_EBANX_Constants;
-use EBANX\Plugin\Services\WC_EBANX_Helper;
 
 /**
  * Class WC_EBANX_Payment_Adapter
@@ -34,7 +34,7 @@ class WC_EBANX_Payment_Adapter {
 				'responsible'         => static::transform_person( $order, $configs, $names, $gateway_id ),
 				'items'               => static::transform_items( $order ),
 				'merchantPaymentCode' => substr( $order->id . '-' . md5( rand( 123123, 9999999 ) ), 0, 40 ),
-				'riskProfileId'       => 'Wx' . str_replace( '.', 'x', WC_EBANX::get_plugin_version() ),
+				'riskProfileId'       => 'Wx' . str_replace( '.', 'x', \WC_EBANX::get_plugin_version() ),
 			]
 		);
 	}
@@ -56,26 +56,26 @@ class WC_EBANX_Payment_Adapter {
 		if ( in_array( $country, WC_EBANX_Constants::$credit_card_countries ) ) {
 			$payment->instalments = '1';
 
-			if ( $configs->settings[ "{$country}_credit_card_instalments" ] > 1 && WC_EBANX_Request::has( 'ebanx_billing_instalments' ) ) {
-				$payment->instalments = WC_EBANX_Request::read( 'ebanx_billing_instalments' );
+			if ( $configs->settings[ "{$country}_credit_card_instalments" ] > 1 && \WC_EBANX_Request::has( 'ebanx_billing_instalments' ) ) {
+				$payment->instalments = \WC_EBANX_Request::read( 'ebanx_billing_instalments' );
 			}
 		}
 
-		if ( ! empty( WC_EBANX_Request::read( 'ebanx_device_fingerprint', null ) ) ) {
-			$payment->device_id = WC_EBANX_Request::read( 'ebanx_device_fingerprint' );
+		if ( ! empty( \WC_EBANX_Request::read( 'ebanx_device_fingerprint', null ) ) ) {
+			$payment->device_id = \WC_EBANX_Request::read( 'ebanx_device_fingerprint' );
 		}
 
-		$token = WC_EBANX_Request::has( 'ebanx_debit_token' )
-			? WC_EBANX_Request::read( 'ebanx_debit_token' )
-			: WC_EBANX_Request::read( 'ebanx_token' );
+		$token = \WC_EBANX_Request::has( 'ebanx_debit_token' )
+			? \WC_EBANX_Request::read( 'ebanx_debit_token' )
+			: \WC_EBANX_Request::read( 'ebanx_token' );
 
-		$brand = WC_EBANX_Request::has( 'ebanx_brand' ) ? WC_EBANX_Request::read( 'ebanx_brand' ) : '';
+		$brand = \WC_EBANX_Request::has( 'ebanx_brand' ) ? \WC_EBANX_Request::read( 'ebanx_brand' ) : '';
 
 		$payment->card = new Card(
 			[
 				'autoCapture' => ( 'yes' === $configs->settings['capture_enabled'] ),
 				'token'       => $token,
-				'cvv'         => WC_EBANX_Request::read( 'ebanx_billing_cvv' ),
+				'cvv'         => \WC_EBANX_Request::read( 'ebanx_billing_cvv' ),
 				'type'        => $brand,
 			]
 		);
@@ -94,7 +94,7 @@ class WC_EBANX_Payment_Adapter {
 	private static function transform_due_date( $configs ) {
 		$due_date = '';
 		if ( ! empty( $configs->settings['due_date_days'] ) ) {
-			$due_date = new DateTime();
+			$due_date = new \DateTime();
 			$due_date->modify( "+{$configs->settings['due_date_days']} day" );
 		}
 
@@ -113,22 +113,22 @@ class WC_EBANX_Payment_Adapter {
 	private static function transform_address( $order, $gateway_id ) {
 
 		if (
-			( empty( WC_EBANX_Request::read( 'billing_postcode', null ) )
-				&& empty( WC_EBANX_Request::read( $gateway_id, null )['billing_postcode'] ) )
-			|| ( empty( WC_EBANX_Request::read( 'billing_address_1', null ) )
-				&& empty( WC_EBANX_Request::read( $gateway_id, null )['billing_address_1'] ) )
-			|| ( empty( WC_EBANX_Request::read( 'billing_city', null ) )
-				&& empty( WC_EBANX_Request::read( $gateway_id, null )['billing_city'] ) )
-			|| ( empty( WC_EBANX_Request::read( 'billing_state', null ) )
-				&& empty( WC_EBANX_Request::read( $gateway_id, null )['billing_state'] ) )
+			( empty( \WC_EBANX_Request::read( 'billing_postcode', null ) )
+				&& empty( \WC_EBANX_Request::read( $gateway_id, null )['billing_postcode'] ) )
+			|| ( empty( \WC_EBANX_Request::read( 'billing_address_1', null ) )
+				&& empty( \WC_EBANX_Request::read( $gateway_id, null )['billing_address_1'] ) )
+			|| ( empty( \WC_EBANX_Request::read( 'billing_city', null ) )
+				&& empty( \WC_EBANX_Request::read( $gateway_id, null )['billing_city'] ) )
+			|| ( empty( \WC_EBANX_Request::read( 'billing_state', null ) )
+				&& empty( \WC_EBANX_Request::read( $gateway_id, null )['billing_state'] ) )
 		) {
 			throw new Exception( 'INVALID-FIELDS' );
 		}
 
-		$addresses = WC_EBANX_Request::read( 'billing_address_1', null ) ?: WC_EBANX_Request::read( $gateway_id, null )['billing_address_1'];
+		$addresses = \WC_EBANX_Request::read( 'billing_address_1', null ) ?: \WC_EBANX_Request::read( $gateway_id, null )['billing_address_1'];
 
-		if ( ! empty( WC_EBANX_Request::read( 'billing_address_2', null ) ) ) {
-			$addresses .= ' - ' . WC_EBANX_Request::read( 'billing_address_2', null );
+		if ( ! empty( \WC_EBANX_Request::read( 'billing_address_2', null ) ) ) {
+			$addresses .= ' - ' . \WC_EBANX_Request::read( 'billing_address_2', null );
 		}
 
 		$addresses     = WC_EBANX_Helper::split_street( $addresses );
@@ -138,10 +138,10 @@ class WC_EBANX_Payment_Adapter {
 			[
 				'address'      => $addresses['streetName'],
 				'streetNumber' => $street_number,
-				'city'         => WC_EBANX_Request::read( 'billing_city', null ) ?: WC_EBANX_Request::read( $gateway_id, null )['billing_city'],
+				'city'         => \WC_EBANX_Request::read( 'billing_city', null ) ?: \WC_EBANX_Request::read( $gateway_id, null )['billing_city'],
 				'country'      => Country::fromIso( $order->billing_country ),
-				'state'        => WC_EBANX_Request::read( 'billing_state', null ) ?: WC_EBANX_Request::read( $gateway_id, null )['billing_state'],
-				'zipcode'      => WC_EBANX_Request::read( 'billing_postcode', null ) ?: WC_EBANX_Request::read( $gateway_id, null )['billing_postcode'],
+				'state'        => \WC_EBANX_Request::read( 'billing_state', null ) ?: \WC_EBANX_Request::read( $gateway_id, null )['billing_state'],
+				'zipcode'      => \WC_EBANX_Request::read( 'billing_postcode', null ) ?: \WC_EBANX_Request::read( $gateway_id, null )['billing_postcode'],
 			]
 		);
 	}
@@ -164,9 +164,9 @@ class WC_EBANX_Payment_Adapter {
 				'type'        => static::get_person_type( $configs, $names ),
 				'document'    => $document,
 				'email'       => $order->billing_email,
-				'ip'          => WC_Geolocation::get_ip_address(),
+				'ip'          => \WC_Geolocation::get_ip_address(),
 				'name'        => $order->billing_first_name . ' ' . $order->billing_last_name,
-				'phoneNumber' => '' !== $order->billing_phone ? $order->billing_phone : WC_EBANX_Request::read( $gateway_id, null )['billing_phone'],
+				'phoneNumber' => '' !== $order->billing_phone ? $order->billing_phone : \WC_EBANX_Request::read( $gateway_id, null )['billing_phone'],
 			]
 		);
 	}
@@ -213,12 +213,12 @@ class WC_EBANX_Payment_Adapter {
 	 * @throws Exception Throws parameter missing exception.
 	 */
 	public static function get_argentinian_document( $names, $gateway_id ) {
-		$document = WC_EBANX_Request::read( $names['ebanx_billing_argentina_document'], null );
+		$document = \WC_EBANX_Request::read( $names['ebanx_billing_argentina_document'], null );
 
 		if ( null === $document
-			&& is_array( WC_EBANX_Request::read( $gateway_id, null ) )
-			&& WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_argentina_document'] ) {
-			$document = WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_argentina_document'];
+			&& is_array( \WC_EBANX_Request::read( $gateway_id, null ) )
+			&& \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_argentina_document'] ) {
+			$document = \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_argentina_document'];
 		}
 
 		if ( null === $document ) {
@@ -238,8 +238,8 @@ class WC_EBANX_Payment_Adapter {
 	 * @throws Exception Throws parameter missing exception.
 	 */
 	public static function get_brazilian_document( $configs, $names, $gateway_id ) {
-		$cpf  = WC_EBANX_Request::read( $names['ebanx_billing_brazil_document'], null ) ?: WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_brazil_document'];
-		$cnpj = WC_EBANX_Request::read( $names['ebanx_billing_brazil_cnpj'], null ) ?: WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_brazil_cnpj'];
+		$cpf  = \WC_EBANX_Request::read( $names['ebanx_billing_brazil_document'], null ) ?: \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_brazil_document'];
+		$cnpj = \WC_EBANX_Request::read( $names['ebanx_billing_brazil_cnpj'], null ) ?: \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_brazil_cnpj'];
 
 		$person_type = static::get_person_type( $configs, $names );
 
@@ -248,8 +248,8 @@ class WC_EBANX_Payment_Adapter {
 
 		if (
 			( Person::TYPE_BUSINESS === $person_type
-				&& ( ! $has_cnpj || ( empty( WC_EBANX_Request::read( 'billing_company', null ) )
-										&& empty( WC_EBANX_Request::read( $gateway_id, null )['billing_company'] ) ) ) )
+				&& ( ! $has_cnpj || ( empty( \WC_EBANX_Request::read( 'billing_company', null ) )
+						&& empty( \WC_EBANX_Request::read( $gateway_id, null )['billing_company'] ) ) ) )
 			|| ( Person::TYPE_PERSONAL === $person_type && ! $has_cpf )
 		) {
 			throw new Exception( 'INVALID-FIELDS' );
@@ -271,8 +271,8 @@ class WC_EBANX_Payment_Adapter {
 	 * @throws Exception Throws parameter missing exception.
 	 */
 	public static function get_chilean_document( $names, $gateway_id ) {
-		$document = WC_EBANX_Request::read( $names['ebanx_billing_chile_document'], null )
-			?: WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_chile_document'];
+		$document = \WC_EBANX_Request::read( $names['ebanx_billing_chile_document'], null )
+			?: \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_chile_document'];
 		if ( null === $document ) {
 			throw new Exception( 'BP-DR-22' );
 		}
@@ -289,8 +289,8 @@ class WC_EBANX_Payment_Adapter {
 	 * @throws Exception Throws parameter missing exception.
 	 */
 	public static function get_colombian_document( $names, $gateway_id ) {
-		$document = WC_EBANX_Request::read( $names['ebanx_billing_colombia_document'], null )
-		?: WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_colombia_document'];
+		$document = \WC_EBANX_Request::read( $names['ebanx_billing_colombia_document'], null )
+			?: \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_colombia_document'];
 		if ( null === $document ) {
 			throw new Exception( 'BP-DR-22' );
 		}
@@ -307,8 +307,8 @@ class WC_EBANX_Payment_Adapter {
 	 * @throws Exception Throws parameter missing exception.
 	 */
 	public static function get_peruvian_document( $names, $gateway_id ) {
-		$document = WC_EBANX_Request::read( $names['ebanx_billing_peru_document'], null )
-			?: WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_peru_document'];
+		$document = \WC_EBANX_Request::read( $names['ebanx_billing_peru_document'], null )
+			?: \WC_EBANX_Request::read( $gateway_id, null )['ebanx_billing_peru_document'];
 		if ( null === $document ) {
 			throw new Exception( 'BP-DR-22' );
 		}
@@ -337,7 +337,7 @@ class WC_EBANX_Payment_Adapter {
 		}
 
 		if ( in_array( 'cpf', $fields_options ) && in_array( 'cnpj', $fields_options ) ) {
-			$person_type = 'cnpj' === WC_EBANX_Request::read( $names['ebanx_billing_brazil_person_type'], 'cpf' ) ? Person::TYPE_BUSINESS : Person::TYPE_PERSONAL;
+			$person_type = 'cnpj' === \WC_EBANX_Request::read( $names['ebanx_billing_brazil_person_type'], 'cpf' ) ? Person::TYPE_BUSINESS : Person::TYPE_PERSONAL;
 		}
 
 		return $person_type;
@@ -352,14 +352,14 @@ class WC_EBANX_Payment_Adapter {
 	private static function transform_items( $order ) {
 		return array_map(
 			function( $product ) {
-					return new Item(
-						[
-							'name'      => $product['name'],
-							'unitPrice' => $product['line_subtotal'],
-							'quantity'  => $product['qty'],
-							'type'      => $product['type'],
-						]
-					);
+				return new Item(
+					[
+						'name'      => $product['name'],
+						'unitPrice' => $product['line_subtotal'],
+						'quantity'  => $product['qty'],
+						'type'      => $product['type'],
+					]
+				);
 			}, $order->get_items()
 		);
 	}

--- a/tests/unit/services/PaymentAdapterTest.php
+++ b/tests/unit/services/PaymentAdapterTest.php
@@ -3,6 +3,7 @@
 use Ebanx\Benjamin\Models\Person;
 use EBANX\Tests\Helpers\Builders\CheckoutRequestBuilder;
 use EBANX\Tests\Helpers\Builders\GlobalConfigBuilder;
+use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
 use PHPUnit\Framework\TestCase;
 
 class PaymentAdapterTest extends TestCase {

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -634,9 +634,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-cancel-order.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-capture-payment.php';
 
-			// Benjamin.
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-payment-adapter.php';
-
 			// Load plugin log classes.
 			self::include_log_classes();
 


### PR DESCRIPTION
This PR change WC_EBANX_Payment_Adapter move from services folder to lib/Plugin/Services folder and add the namespace EBANX\Plugin\Services.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Payment_Adapter in the project.