### PR TITLE
Remove require command from WC_EBANX_Assets and start use a namespace

### DIFF
--- a/lib/Plugin/Services/WC_EBANX_Assets.php
+++ b/lib/Plugin/Services/WC_EBANX_Assets.php
@@ -1,5 +1,7 @@
 <?php
 
+namespace EBANX\Plugin\Services;
+
 /**
  * Class WC_EBANX_Assets
  */
@@ -91,8 +93,8 @@ SVG;
 	 * @throws Exception Shows missing param message.
 	 */
 	private static function is_in_ebanx_settings() {
-		return WC_EBANX_Request::has( 'section' )
-			&& WC_EBANX_Request::read( 'section' ) === 'ebanx-global';
+		return \WC_EBANX_Request::has( 'section' )
+			&& \WC_EBANX_Request::read( 'section' ) === 'ebanx-global';
 	}
 
 	/**
@@ -105,13 +107,13 @@ SVG;
 	 */
 	private static function render_script( $filename, $dependencies = array() ) {
 		$script_name = 'woocommerce_ebanx_' . str_replace( '-', '_', $filename );
-		$file_path   = plugins_url( 'assets/js/' . $filename . '.js', WC_EBANX::DIR );
+		$file_path   = plugins_url( 'assets/js/' . $filename . '.js', \WC_EBANX::DIR );
 
 		wp_enqueue_script(
 			$script_name,
 			$file_path,
 			$dependencies,
-			WC_EBANX::get_plugin_version(),
+			\WC_EBANX::get_plugin_version(),
 			true
 		);
 	}
@@ -138,7 +140,7 @@ SVG;
 	 */
 	private static function render_style( $filename ) {
 		$style_name = 'woocommerce_ebanx_' . str_replace( '-', '_', $filename );
-		$file_path  = plugins_url( 'assets/css/' . $filename . '.css', WC_EBANX::DIR );
+		$file_path  = plugins_url( 'assets/css/' . $filename . '.css', \WC_EBANX::DIR );
 
 		wp_enqueue_style(
 			$style_name,

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -38,6 +38,7 @@ require_once WC_EBANX_VENDOR_DIR . '/autoload.php';
 use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Notice;
 use EBANX\Plugin\Services\WC_EBANX_Query_Router;
+use EBANX\Plugin\Services\WC_EBANX_Assets;
 
 if ( ! class_exists( 'WC_EBANX' ) ) {
 	/**
@@ -133,7 +134,7 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			add_action( 'woocommerce_order_actions', array( 'WC_EBANX_Capture_Payment', 'add_auto_capture_dropdown' ) );
 			add_action( 'woocommerce_order_action_ebanx_capture_order', array( 'WC_EBANX_Capture_Payment', 'capture_from_order_dropdown' ) );
 
-			add_action( 'admin_footer', array( 'WC_EBANX_Assets', 'render' ), 0 );
+			add_action( 'admin_footer', array( '\EBANX\Plugin\Services\WC_EBANX_Assets', 'render' ), 0 );
 
 			add_action( 'woocommerce_settings_save_checkout', array( $this, 'on_before_save_settings' ), 10 );
 			add_action( 'woocommerce_settings_saved', array( $this, 'setup_configs' ), 10 );
@@ -629,7 +630,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-checker.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-flash.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-request.php';
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-assets.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-third-party-compability-layer.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-cancel-order.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-capture-payment.php';


### PR DESCRIPTION
This PR change WC_EBANX_Assets move from services folder to lib/Plugin/Services folder and add the namespace EBANX\Plugin\Services.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Assets in the project.