### PR TITLE
Remove require command from WC_EBANX_Cancel_Order and start use a namespace

### DIFF
--- a/lib/Plugin/Services/WC_EBANX_Cancel_Order.php
+++ b/lib/Plugin/Services/WC_EBANX_Cancel_Order.php
@@ -1,10 +1,6 @@
 <?php
 
-use EBANX\Plugin\Services\WC_EBANX_Constants;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+namespace EBANX\Plugin\Services;
 
 /**
  * Class WC_EBANX_Cancel_Order

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			 */
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
-			add_filter( 'woocommerce_my_account_my_orders_actions', array( 'WC_EBANX_Cancel_Order', 'add_my_account_cancel_order_action' ), 10, 2 );
+			add_filter( 'woocommerce_my_account_my_orders_actions', array( '\EBANX\Plugin\Services\WC_EBANX_Cancel_Order', 'add_my_account_cancel_order_action' ), 10, 2 );
 			add_filter( 'woocommerce_admin_order_actions', array( 'WC_EBANX_Capture_Payment', 'add_order_capture_button' ), 10, 2 );
 
 			add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'get_instalments_admin_html' ) );
@@ -631,7 +631,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-flash.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-request.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-third-party-compability-layer.php';
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-cancel-order.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-capture-payment.php';
 
 			// Load plugin log classes.


### PR DESCRIPTION
This PR change WC_EBANX_Cancel_Order  move from services folder to lib/Plugin/Services folder and add the namespace EBANX\Plugin\Services.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Cancel_Order  in the project.