### PR TITLE
Remove require command from WC_EBANX_Capture_Payment and start use a namespace

### DIFF
--- a/controllers/class-wc-ebanx-api-controller.php
+++ b/controllers/class-wc-ebanx-api-controller.php
@@ -7,6 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Helper;
 use EBANX\Plugin\Services\WC_EBANX_Api;
+use EBANX\Plugin\Services\WC_EBANX_Capture_Payment;
 
 /**
  * Class WC_EBANX_Api_Controller

--- a/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -10,6 +10,7 @@ use EBANX\Plugin\Services\WC_EBANX_Constants;
 use EBANX\Plugin\Services\WC_EBANX_Helper;
 use EBANX\Plugin\Services\WC_EBANX_Api;
 use EBANX\Plugin\Services\WC_EBANX_Payment_Adapter;
+use EBANX\Plugin\Services\WC_EBANX_Capture_Payment;
 
 /**
  * Class WC_EBANX_Credit_Card_Gateway

--- a/lib/Plugin/Services/WC_EBANX_Cancel_Order.php
+++ b/lib/Plugin/Services/WC_EBANX_Cancel_Order.php
@@ -1,10 +1,6 @@
 <?php
 
-use EBANX\Plugin\Services\WC_EBANX_Constants;
-
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+namespace EBANX\Plugin\Services;
 
 /**
  * Class WC_EBANX_Cancel_Order

--- a/lib/Plugin/Services/WC_EBANX_Capture_Payment.php
+++ b/lib/Plugin/Services/WC_EBANX_Capture_Payment.php
@@ -1,11 +1,8 @@
 <?php
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+namespace EBANX\Plugin\Services;
 
 use Ebanx\Benjamin\Models\Configs\CreditCardConfig;
-use EBANX\Plugin\Services\WC_EBANX_Api;
 
 /**
  * Class WC_EBANX_Capture_Payment
@@ -86,8 +83,8 @@ class WC_EBANX_Capture_Payment {
 	 * @return void
 	 */
 	public static function capture_payment( $order_id ) {
-		$configs = new WC_EBANX_Global_Gateway();
-		$order   = new WC_Order( $order_id );
+		$configs = new \WC_EBANX_Global_Gateway();
+		$order   = new \WC_Order( $order_id );
 		$payment_hash = get_post_meta( $order_id, '_ebanx_payment_hash', true );
 		$ebanx        = ( new WC_EBANX_Api( $configs ) )->ebanx();
 		$payment_data = $ebanx->paymentInfo()->findByHash( $payment_hash );
@@ -107,15 +104,15 @@ class WC_EBANX_Capture_Payment {
 			$is_recapture                  = 'BP-CAP-4' === $error->code;
 			$response['payment']['status'] = $error->status;
 
-			WC_EBANX::log( $error->message );
-			WC_EBANX_Flash::add_message( $error->message, 'warning', true );
+			\WC_EBANX::log( $error->message );
+			\WC_EBANX_Flash::add_message( $error->message, 'warning', true );
 		}
 		if ( 'CO' === $response['payment']['status'] ) {
 			$order->payment_complete();
 
 			if ( ! $is_recapture ) {
 				$order->add_order_note( sprintf( __( 'EBANX: The transaction was captured with the following: %s', 'woocommerce-gateway-ebanx' ), wp_get_current_user()->data->user_email ) );
-				WC_EBANX_Flash::add_message( sprintf( __( 'Payment %s was captured successfully.', 'woocommerce-gateway-ebanx' ), $order_id ), 'warning', true );
+				\WC_EBANX_Flash::add_message( sprintf( __( 'Payment %s was captured successfully.', 'woocommerce-gateway-ebanx' ), $order_id ), 'warning', true );
 			}
 		} elseif ( 'CA' === $response['payment']['status'] ) {
 			$order->update_status( 'failed' );
@@ -174,7 +171,7 @@ class WC_EBANX_Capture_Payment {
 	 */
 	private static function get_credit_card_config( $country_abbr ) {
 		$currency_code = strtolower( get_woocommerce_currency() );
-		$configs = new WC_EBANX_Global_Gateway();
+		$configs = new \WC_EBANX_Global_Gateway();
 
 		$credit_card_config = new CreditCardConfig(
 			array(

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -173,7 +173,7 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			 */
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
-			add_filter( 'woocommerce_my_account_my_orders_actions', array( 'WC_EBANX_Cancel_Order', 'add_my_account_cancel_order_action' ), 10, 2 );
+			add_filter( 'woocommerce_my_account_my_orders_actions', array( '\EBANX\Plugin\Services\WC_EBANX_Cancel_Order', 'add_my_account_cancel_order_action' ), 10, 2 );
 			add_filter( 'woocommerce_admin_order_actions', array( 'WC_EBANX_Capture_Payment', 'add_order_capture_button' ), 10, 2 );
 
 			add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'get_instalments_admin_html' ) );
@@ -631,7 +631,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-flash.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-request.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-third-party-compability-layer.php';
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-cancel-order.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-capture-payment.php';
 
 			// Load plugin log classes.

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -129,10 +129,10 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 				add_action( 'admin_init', array( $this, 'checker' ), 30 );
 			}
 
-			add_action( 'admin_head', array( 'WC_EBANX_Capture_Payment', 'add_order_capture_button_css' ) );
+			add_action( 'admin_head', array( '\EBANX\Plugin\Services\WC_EBANX_Capture_Payment', 'add_order_capture_button_css' ) );
 
-			add_action( 'woocommerce_order_actions', array( 'WC_EBANX_Capture_Payment', 'add_auto_capture_dropdown' ) );
-			add_action( 'woocommerce_order_action_ebanx_capture_order', array( 'WC_EBANX_Capture_Payment', 'capture_from_order_dropdown' ) );
+			add_action( 'woocommerce_order_actions', array( '\EBANX\Plugin\Services\WC_EBANX_Capture_Payment', 'add_auto_capture_dropdown' ) );
+			add_action( 'woocommerce_order_action_ebanx_capture_order', array( '\EBANX\Plugin\Services\WC_EBANX_Capture_Payment', 'capture_from_order_dropdown' ) );
 
 			add_action( 'admin_footer', array( '\EBANX\Plugin\Services\WC_EBANX_Assets', 'render' ), 0 );
 
@@ -174,7 +174,7 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			add_filter( 'woocommerce_payment_gateways', array( $this, 'add_gateway' ) );
 			add_filter( 'plugin_action_links_' . plugin_basename( __FILE__ ), array( $this, 'plugin_action_links' ) );
 			add_filter( 'woocommerce_my_account_my_orders_actions', array( '\EBANX\Plugin\Services\WC_EBANX_Cancel_Order', 'add_my_account_cancel_order_action' ), 10, 2 );
-			add_filter( 'woocommerce_admin_order_actions', array( 'WC_EBANX_Capture_Payment', 'add_order_capture_button' ), 10, 2 );
+			add_filter( 'woocommerce_admin_order_actions', array( '\EBANX\Plugin\Services\WC_EBANX_Capture_Payment', 'add_order_capture_button' ), 10, 2 );
 
 			add_action( 'woocommerce_admin_order_data_after_billing_address', array( $this, 'get_instalments_admin_html' ) );
 
@@ -631,7 +631,6 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-flash.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-request.php';
 			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-third-party-compability-layer.php';
-			include_once WC_EBANX_SERVICES_DIR . 'class-wc-ebanx-capture-payment.php';
 
 			// Load plugin log classes.
 			self::include_log_classes();


### PR DESCRIPTION
This PR change WC_EBANX_Capture_Payment move from services folder to lib/Plugin/Services folder and add the namespace EBANX\Plugin\Services.

With this change, we remove the require command to load this class in our Plugin and use the namespace to load the WC_EBANX_Capture_Payment in the project.