### PR TITLE
Use get_id() when user the order id

### DIFF
--- a/gateways/class-wc-ebanx-baloto-gateway.php
+++ b/gateways/class-wc-ebanx-baloto-gateway.php
@@ -84,7 +84,7 @@ class WC_EBANX_Baloto_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_baloto_url', $request->payment->baloto_url );
+		update_post_meta( $order->get_id(), '_baloto_url', $request->payment->baloto_url );
 	}
 
 	/**
@@ -94,12 +94,12 @@ class WC_EBANX_Baloto_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$baloto_url     = get_post_meta( $order->id, '_baloto_url', true );
+		$baloto_url     = get_post_meta( $order->get_id(), '_baloto_url', true );
 		$baloto_basic   = $baloto_url . '&format=basic';
 		$baloto_pdf     = $baloto_url . '&format=pdf';
 		$baloto_print   = $baloto_url . '&format=print';
-		$customer_email = get_post_meta( $order->id, '_ebanx_payment_customer_email', true );
-		$baloto_hash    = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$customer_email = get_post_meta( $order->get_id(), '_ebanx_payment_customer_email', true );
+		$baloto_hash    = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 
 		$data = array(
 			'data'         => array(

--- a/gateways/class-wc-ebanx-bank-transfer-gateway.php
+++ b/gateways/class-wc-ebanx-bank-transfer-gateway.php
@@ -110,8 +110,8 @@ class WC_EBANX_Bank_Transfer_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_payment_due_date', $request->payment->due_date );
-		update_post_meta( $order->id, '_voucher_url', $request->payment->voucher_url );
+		update_post_meta( $order->get_id(), '_payment_due_date', $request->payment->due_date );
+		update_post_meta( $order->get_id(), '_voucher_url', $request->payment->voucher_url );
 	}
 
 	/**
@@ -121,7 +121,7 @@ class WC_EBANX_Bank_Transfer_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$bank_transfer_url            = get_post_meta( $order->id, '_voucher_url', true );
+		$bank_transfer_url            = get_post_meta( $order->get_id(), '_voucher_url', true );
 		wp_redirect( $bank_transfer_url );
 	}
 }

--- a/gateways/class-wc-ebanx-banking-ticket-gateway.php
+++ b/gateways/class-wc-ebanx-banking-ticket-gateway.php
@@ -99,9 +99,9 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_payment_due_date', $request->payment->due_date );
-		update_post_meta( $order->id, '_boleto_url', $request->payment->boleto_url );
-		update_post_meta( $order->id, '_boleto_barcode', $request->payment->boleto_barcode );
+		update_post_meta( $order->get_id(), '_payment_due_date', $request->payment->due_date );
+		update_post_meta( $order->get_id(), '_boleto_url', $request->payment->boleto_url );
+		update_post_meta( $order->get_id(), '_boleto_barcode', $request->payment->boleto_barcode );
 	}
 
 	/**
@@ -134,16 +134,16 @@ class WC_EBANX_Banking_Ticket_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$boleto_url         = get_post_meta( $order->id, '_boleto_url', true );
+		$boleto_url         = get_post_meta( $order->get_id(), '_boleto_url', true );
 		$boleto_basic       = $boleto_url . '&format=basic';
 		$boleto_pdf         = $boleto_url . '&format=pdf';
 		$boleto_print       = $boleto_url . '&format=print';
 		$boleto_mobile      = $boleto_url . '&device_target=mobile';
-		$barcode            = get_post_meta( $order->id, '_boleto_barcode', true );
-		$customer_email     = get_post_meta( $order->id, '_billing_email', true );
-		$customer_name      = get_post_meta( $order->id, '_billing_first_name', true );
-		$boleto_due_date    = get_post_meta( $order->id, '_payment_due_date', true );
-		$boleto_hash        = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$barcode            = get_post_meta( $order->get_id(), '_boleto_barcode', true );
+		$customer_email     = get_post_meta( $order->get_id(), '_billing_email', true );
+		$customer_name      = get_post_meta( $order->get_id(), '_billing_first_name', true );
+		$boleto_due_date    = get_post_meta( $order->get_id(), '_payment_due_date', true );
+		$boleto_hash        = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 		$barcode_anti_fraud = WC_EBANX_Banking_Ticket_Gateway::barcode_anti_fraud( $barcode );
 
 		$data = array(

--- a/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -194,7 +194,7 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 				$order_id  = absint( $_GET['order_id'] );
 				$order     = wc_get_order( $order_id );
 
-				if ( $order->id === $order_id && $order->order_key === $order_key ) {
+				if ( $order->get_id() === $order_id && $order->order_key === $order_key ) {
 					static::$ebanx_params['billing_first_name'] = $order->billing_first_name;
 					static::$ebanx_params['billing_last_name']  = $order->billing_last_name;
 					static::$ebanx_params['billing_address_1']  = $order->billing_address_1;
@@ -261,9 +261,9 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_cards_brand_name', $request->payment->payment_type_code );
-		update_post_meta( $order->id, '_instalments_number', $request->payment->instalments );
-		update_post_meta( $order->id, '_masked_card_number', WC_EBANX_Request::read( 'ebanx_masked_card_number' ) );
+		update_post_meta( $order->get_id(), '_cards_brand_name', $request->payment->payment_type_code );
+		update_post_meta( $order->get_id(), '_instalments_number', $request->payment->instalments );
+		update_post_meta( $order->get_id(), '_masked_card_number', WC_EBANX_Request::read( 'ebanx_masked_card_number' ) );
 	}
 
 	/**
@@ -351,8 +351,8 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 	 */
 	public static function thankyou_page( $order ) {
 		$order_amount       = $order->get_total();
-		$instalments_number = get_post_meta( $order->id, '_instalments_number', true ) ?: 1;
-		$country            = trim( strtolower( get_post_meta( $order->id, '_billing_country', true ) ) );
+		$instalments_number = get_post_meta( $order->get_id(), '_instalments_number', true ) ?: 1;
+		$country            = trim( strtolower( get_post_meta( $order->get_id(), '_billing_country', true ) ) );
 		$currency           = $order->get_order_currency();
 
 		if ( WC_EBANX_Constants::COUNTRY_BRAZIL === $country && WC_EBANX_Helper::should_apply_taxes() ) {
@@ -361,14 +361,14 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 
 		$data = array(
 			'data'         => array(
-				'card_brand_name'    => get_post_meta( $order->id, '_cards_brand_name', true ),
+				'card_brand_name'    => get_post_meta( $order->get_id(), '_cards_brand_name', true ),
 				'instalments_number' => $instalments_number,
 				'instalments_amount' => wc_price( round( $order_amount / $instalments_number, 2 ), array( 'currency' => $currency ) ),
-				'masked_card'        => substr( get_post_meta( $order->id, '_masked_card_number', true ), -4 ),
+				'masked_card'        => substr( get_post_meta( $order->get_id(), '_masked_card_number', true ), -4 ),
 				'customer_email'     => $order->billing_email,
 				'customer_name'      => $order->billing_first_name,
 				'total'              => wc_price( $order_amount, array( 'currency' => $currency ) ),
-				'hash'               => get_post_meta( $order->id, '_ebanx_payment_hash', true ),
+				'hash'               => get_post_meta( $order->get_id(), '_ebanx_payment_hash', true ),
 			),
 			'order_status' => $order->get_status(),
 			'method'       => $order->payment_method,

--- a/gateways/class-wc-ebanx-debit-card-gateway.php
+++ b/gateways/class-wc-ebanx-debit-card-gateway.php
@@ -133,8 +133,8 @@ class WC_EBANX_Debit_Card_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_cards_brand_name', $request->payment->payment_type_code );
-		update_post_meta( $order->id, '_masked_card_number', WC_EBANX_Request::read( 'ebanx_masked_card_number' ) );
+		update_post_meta( $order->get_id(), '_cards_brand_name', $request->payment->payment_type_code );
+		update_post_meta( $order->get_id(), '_masked_card_number', WC_EBANX_Request::read( 'ebanx_masked_card_number' ) );
 	}
 
 	/**
@@ -148,9 +148,9 @@ class WC_EBANX_Debit_Card_Gateway extends WC_EBANX_New_Gateway {
 
 		$data = array(
 			'data'         => array(
-				'card_brand_name' => get_post_meta( $order->id, '_cards_brand_name', true ),
+				'card_brand_name' => get_post_meta( $order->get_id(), '_cards_brand_name', true ),
 				'order_amount'    => $order_amount,
-				'masked_card'     => substr( get_post_meta( $order->id, '_masked_card_number', true ), -4 ),
+				'masked_card'     => substr( get_post_meta( $order->get_id(), '_masked_card_number', true ), -4 ),
 				'customer_email'  => $order->billing_email,
 				'customer_name'   => $order->billing_first_name,
 			),

--- a/gateways/class-wc-ebanx-efectivo-gateway.php
+++ b/gateways/class-wc-ebanx-efectivo-gateway.php
@@ -85,7 +85,7 @@ class WC_EBANX_Efectivo_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_efectivo_url', $request->payment->voucher_url );
+		update_post_meta( $order->get_id(), '_efectivo_url', $request->payment->voucher_url );
 	}
 
 	/**
@@ -95,12 +95,12 @@ class WC_EBANX_Efectivo_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$efectivo_url   = get_post_meta( $order->id, '_efectivo_url', true );
+		$efectivo_url   = get_post_meta( $order->get_id(), '_efectivo_url', true );
 		$efectivo_basic = $efectivo_url . '&format=basic';
 		$efectivo_pdf   = $efectivo_url . '&format=pdf';
 		$efectivo_print = $efectivo_url . '&format=print';
-		$customer_email = get_post_meta( $order->id, '_ebanx_payment_customer_email', true );
-		$efectivo_hash  = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$customer_email = get_post_meta( $order->get_id(), '_ebanx_payment_customer_email', true );
+		$efectivo_hash  = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 
 		$data = array(
 			'data'         => array(

--- a/gateways/class-wc-ebanx-gateway.php
+++ b/gateways/class-wc-ebanx-gateway.php
@@ -382,19 +382,19 @@ class WC_EBANX_Gateway extends WC_Payment_Gateway {
 	 */
 	protected function save_order_meta_fields( $order, $request ) {
 		// To save only on DB to internal use.
-		update_post_meta( $order->id, '_ebanx_payment_hash', $request->payment->hash );
-		update_post_meta( $order->id, '_ebanx_payment_open_date', $request->payment->open_date );
+		update_post_meta( $order->get_id(), '_ebanx_payment_hash', $request->payment->hash );
+		update_post_meta( $order->get_id(), '_ebanx_payment_open_date', $request->payment->open_date );
 
 		if ( WC_EBANX_Request::has( 'billing_email' ) ) {
-			update_post_meta( $order->id, '_ebanx_payment_customer_email', sanitize_email( WC_EBANX_Request::read( 'billing_email' ) ) );
+			update_post_meta( $order->get_id(), '_ebanx_payment_customer_email', sanitize_email( WC_EBANX_Request::read( 'billing_email' ) ) );
 		}
 
 		if ( WC_EBANX_Request::has( 'billing_phone' ) ) {
-			update_post_meta( $order->id, '_ebanx_payment_customer_phone', sanitize_text_field( WC_EBANX_Request::read( 'billing_phone' ) ) );
+			update_post_meta( $order->get_id(), '_ebanx_payment_customer_phone', sanitize_text_field( WC_EBANX_Request::read( 'billing_phone' ) ) );
 		}
 
 		if ( WC_EBANX_Request::has( 'billing_address_1' ) ) {
-			update_post_meta( $order->id, '_ebanx_payment_customer_address', sanitize_text_field( WC_EBANX_Request::read( 'billing_address_1' ) ) );
+			update_post_meta( $order->get_id(), '_ebanx_payment_customer_address', sanitize_text_field( WC_EBANX_Request::read( 'billing_address_1' ) ) );
 		}
 	}
 

--- a/gateways/class-wc-ebanx-new-gateway.php
+++ b/gateways/class-wc-ebanx-new-gateway.php
@@ -710,7 +710,7 @@ class WC_EBANX_New_Gateway extends WC_EBANX_Gateway {
 	 * @return void
 	 */
 	final public function process_refund_hook( $order, $data ) {
-		$refunds = current( get_post_meta( $order->id, '_ebanx_payment_refunds' ) );
+		$refunds = current( get_post_meta( $order->get_id(), '_ebanx_payment_refunds' ) );
 
 		foreach ( $refunds as $k => $ref ) {
 			foreach ( $data['payment']['refunds'] as $refund ) {
@@ -733,7 +733,7 @@ class WC_EBANX_New_Gateway extends WC_EBANX_Gateway {
 			}
 		}
 
-		update_post_meta( $order->id, '_ebanx_payment_refunds', $refunds );
+		update_post_meta( $order->get_id(), '_ebanx_payment_refunds', $refunds );
 	}
 
 	/**

--- a/gateways/class-wc-ebanx-oxxo-gateway.php
+++ b/gateways/class-wc-ebanx-oxxo-gateway.php
@@ -84,8 +84,8 @@ class WC_EBANX_Oxxo_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_oxxo_url', $request->payment->oxxo_url );
-		update_post_meta( $order->id, '_payment_due_date', $request->payment->due_date );
+		update_post_meta( $order->get_id(), '_oxxo_url', $request->payment->oxxo_url );
+		update_post_meta( $order->get_id(), '_payment_due_date', $request->payment->due_date );
 	}
 
 	/**
@@ -95,14 +95,14 @@ class WC_EBANX_Oxxo_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$oxxo_url       = get_post_meta( $order->id, '_oxxo_url', true );
+		$oxxo_url       = get_post_meta( $order->get_id(), '_oxxo_url', true );
 		$oxxo_basic     = $oxxo_url . '&format=basic';
 		$oxxo_pdf       = $oxxo_url . '&format=pdf';
 		$oxxo_print     = $oxxo_url . '&format=print';
-		$customer_email = get_post_meta( $order->id, '_ebanx_payment_customer_email', true );
-		$oxxo_hash      = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$customer_email = get_post_meta( $order->get_id(), '_ebanx_payment_customer_email', true );
+		$oxxo_hash      = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 		$customer_name  = $order->billing_first_name;
-		$oxxo_due_date  = get_post_meta( $order->id, '_payment_due_date', true );
+		$oxxo_due_date  = get_post_meta( $order->get_id(), '_payment_due_date', true );
 
 		$data = array(
 			'data'         => array(

--- a/gateways/class-wc-ebanx-pagoefectivo-gateway.php
+++ b/gateways/class-wc-ebanx-pagoefectivo-gateway.php
@@ -84,7 +84,7 @@ class WC_EBANX_Pagoefectivo_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_pagoefectivo_url', $request->redirect_url );
+		update_post_meta( $order->get_id(), '_pagoefectivo_url', $request->redirect_url );
 	}
 
 	/**
@@ -94,8 +94,8 @@ class WC_EBANX_Pagoefectivo_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$pagoefectivo_url  = get_post_meta( $order->id, '_pagoefectivo_url', true );
-		$pagoefectivo_hash = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$pagoefectivo_url  = get_post_meta( $order->get_id(), '_pagoefectivo_url', true );
+		$pagoefectivo_hash = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 
 		$data = array(
 			'data'         => array(

--- a/gateways/class-wc-ebanx-redirect-gateway.php
+++ b/gateways/class-wc-ebanx-redirect-gateway.php
@@ -35,7 +35,7 @@ abstract class WC_EBANX_Redirect_Gateway extends WC_EBANX_New_Gateway {
 
 		parent::process_response( $response, $order );
 
-		update_post_meta( $order->id, '_ebanx_payment_hash', $response['payment']['hash'] );
+		update_post_meta( $order->get_id(), '_ebanx_payment_hash', $response['payment']['hash'] );
 
 		$this->redirect_url = $redirect;
 	}

--- a/gateways/class-wc-ebanx-spei-gateway.php
+++ b/gateways/class-wc-ebanx-spei-gateway.php
@@ -84,8 +84,8 @@ class WC_EBANX_Spei_Gateway extends WC_EBANX_New_Gateway {
 	protected function save_order_meta_fields( $order, $request ) {
 		parent::save_order_meta_fields( $order, $request );
 
-		update_post_meta( $order->id, '_spei_url', $request->payment->spei_url );
-		update_post_meta( $order->id, '_payment_due_date', $request->payment->due_date );
+		update_post_meta( $order->get_id(), '_spei_url', $request->payment->spei_url );
+		update_post_meta( $order->get_id(), '_payment_due_date', $request->payment->due_date );
 	}
 
 	/**
@@ -95,14 +95,14 @@ class WC_EBANX_Spei_Gateway extends WC_EBANX_New_Gateway {
 	 * @return void
 	 */
 	public static function thankyou_page( $order ) {
-		$spei_url       = get_post_meta( $order->id, '_spei_url', true );
+		$spei_url       = get_post_meta( $order->get_id(), '_spei_url', true );
 		$spei_basic     = $spei_url . '&format=basic';
 		$spei_pdf       = $spei_url . '&format=pdf';
 		$spei_print     = $spei_url . '&format=print';
-		$customer_email = get_post_meta( $order->id, '_ebanx_payment_customer_email', true );
+		$customer_email = get_post_meta( $order->get_id(), '_ebanx_payment_customer_email', true );
 		$customer_name  = $order->billing_first_name;
-		$spei_due_date  = get_post_meta( $order->id, '_payment_due_date', true );
-		$spei_hash = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$spei_due_date  = get_post_meta( $order->get_id(), '_payment_due_date', true );
+		$spei_hash = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 
 		$data       = array(
 			'data'         => array(

--- a/gateways/class-wc-ebanx-tef-gateway.php
+++ b/gateways/class-wc-ebanx-tef-gateway.php
@@ -85,8 +85,8 @@ class WC_EBANX_Tef_Gateway extends WC_EBANX_Redirect_Gateway {
 	public static function thankyou_page( $order ) {
 		$data = array(
 			'data'         => array(
-				'bank_name'     => get_post_meta( $order->id, '_ebanx_tef_bank', true ),
-				'customer_name' => get_post_meta( $order->id, '_billing_first_name', true ),
+				'bank_name'     => get_post_meta( $order->get_id(), '_ebanx_tef_bank', true ),
+				'customer_name' => get_post_meta( $order->get_id(), '_billing_first_name', true ),
 			),
 			'order_status' => $order->get_status(),
 			'method'       => 'tef',
@@ -105,7 +105,7 @@ class WC_EBANX_Tef_Gateway extends WC_EBANX_Redirect_Gateway {
 	 * @throws Exception Throw parameter missing exception.
 	 */
 	protected function save_order_meta_fields( $order, $request ) {
-		update_post_meta( $order->id, '_ebanx_tef_bank', sanitize_text_field( WC_EBANX_Request::read( 'tef' ) ) );
+		update_post_meta( $order->get_id(), '_ebanx_tef_bank', sanitize_text_field( WC_EBANX_Request::read( 'tef' ) ) );
 
 		parent::save_order_meta_fields( $order, $request );
 	}

--- a/lib/Plugin/Services/WC_EBANX_My_Account.php
+++ b/lib/Plugin/Services/WC_EBANX_My_Account.php
@@ -42,7 +42,7 @@ class WC_EBANX_My_Account {
 	 */
 	public function my_orders_banking_ticket_link( $actions, $order ) {
 		if ( 'ebanx-banking-ticket' === $order->payment_method && in_array( $order->get_status(), array( 'pending', 'on-hold' ) ) ) {
-			$url = get_post_meta( $order->id, 'Banking Ticket URL', true );
+			$url = get_post_meta( $order->get_id(), 'Banking Ticket URL', true );
 
 			if ( ! empty( $url ) ) {
 				$actions[] = array(
@@ -63,7 +63,7 @@ class WC_EBANX_My_Account {
 	 */
 	public static function order_details( $order ) {
 		// For test purposes.
-		$hash = get_post_meta( $order->id, '_ebanx_payment_hash', true );
+		$hash = get_post_meta( $order->get_id(), '_ebanx_payment_hash', true );
 
 		printf( '<input type="hidden" name="ebanx_payment_hash" value="%s" />', $hash ); // phpcs:ignore WordPress.XSS.EscapeOutput
 

--- a/lib/Plugin/Services/WC_EBANX_Payment_Adapter.php
+++ b/lib/Plugin/Services/WC_EBANX_Payment_Adapter.php
@@ -27,13 +27,13 @@ class WC_EBANX_Payment_Adapter {
 		return new Payment(
 			[
 				'amountTotal'         => $order->get_total(),
-				'orderNumber'         => $order->id,
+				'orderNumber'         => $order->get_id(),
 				'dueDate'             => static::transform_due_date( $configs ),
 				'address'             => static::transform_address( $order, $gateway_id ),
 				'person'              => static::transform_person( $order, $configs, $names, $gateway_id ),
 				'responsible'         => static::transform_person( $order, $configs, $names, $gateway_id ),
 				'items'               => static::transform_items( $order ),
-				'merchantPaymentCode' => substr( $order->id . '-' . md5( rand( 123123, 9999999 ) ), 0, 40 ),
+				'merchantPaymentCode' => substr( $order->get_id() . '-' . md5( rand( 123123, 9999999 ) ), 0, 40 ),
 				'riskProfileId'       => 'Wx' . str_replace( '.', 'x', \WC_EBANX::get_plugin_version() ),
 			]
 		);
@@ -417,14 +417,14 @@ class WC_EBANX_Payment_Adapter {
 		return new Payment(
 			[
 				'amountTotal'         => $order->get_total(),
-				'orderNumber'         => $order->id,
+				'orderNumber'         => $order->get_id(),
 				'dueDate'             => static::transform_due_date( $configs ),
 				'address'             => static::transform_address_from_post_data( $order ),
 				'person'              => static::transform_person_from_post_data( $order, $configs ),
 				'responsible'         => static::transform_person_from_post_data( $order, $configs ),
 				'instalments'         => '1',
 				'items'               => static::transform_items( $order ),
-				'merchantPaymentCode' => substr( $order->id . '-' . md5( rand( 123123, 9999999 ) ), 0, 40 ),
+				'merchantPaymentCode' => substr( $order->get_id() . '-' . md5( rand( 123123, 9999999 ) ), 0, 40 ),
 				'riskProfileId'       => 'Wx' . str_replace( '.', 'x', WC_EBANX::get_plugin_version() ),
 			]
 		);
@@ -479,7 +479,7 @@ class WC_EBANX_Payment_Adapter {
 		if ( count( $fields_options ) === 1 && 'cnpj' === $fields_options[0] ) {
 			return Person::TYPE_BUSINESS;
 		}
-		$brazil_person_type = get_post_meta( $order->id, '_billing_persontype', true );
+		$brazil_person_type = get_post_meta( $order->get_id(), '_billing_persontype', true );
 		if ( empty( $brazil_person_type ) ) {
 			return Person::TYPE_PERSONAL;
 		}
@@ -498,8 +498,8 @@ class WC_EBANX_Payment_Adapter {
 	 * @throws Exception Throws parameter missing exception.
 	 */
 	private static function get_document_from_order( $order, $person_type ) {
-		$cpf  = get_post_meta( $order->id, '_billing_cpf', true );
-		$cnpj = get_post_meta( $order->id, '_billing_cnpj', true );
+		$cpf  = get_post_meta( $order->get_id(), '_billing_cpf', true );
+		$cnpj = get_post_meta( $order->get_id(), '_billing_cnpj', true );
 		$has_cpf  = ! empty( $cpf );
 		$has_cnpj = ! empty( $cnpj );
 		if ( Person::TYPE_PERSONAL === $person_type && $has_cpf ) {

--- a/services/class-wc-ebanx-one-click.php
+++ b/services/class-wc-ebanx-one-click.php
@@ -198,12 +198,12 @@ class WC_EBANX_One_Click {
 			$order->save();
 
 			foreach ( $meta as $meta_key => $meta_value ) {
-				update_post_meta( $order->id, $meta_key, $meta_value );
+				update_post_meta( $order->get_id(), $meta_key, $meta_value );
 			}
 
 			$order->calculate_totals();
 
-			$response = $this->gateway->process_payment( $order->id );
+			$response = $this->gateway->process_payment( $order->get_id() );
 
 			if ( 'success' !== $response['result'] ) {
 				$message = __( 'EBANX: Unable to create the payment via one click.', 'woocommerce-gateway-ebanx' );

--- a/services/class-wc-ebanx-payment-by-link.php
+++ b/services/class-wc-ebanx-payment-by-link.php
@@ -124,11 +124,11 @@ class WC_EBANX_Payment_By_Link {
 			[
 				'person'              => $person,
 				'address'             => $address,
-				'orderNumber'         => self::$order->id,
+				'orderNumber'         => self::$order->get_id(),
 				'type'                => empty( self::$order->payment_method ) ? '_all' : WC_EBANX_Constants::$gateway_to_payment_type_code[ self::$order->payment_method ],
-				'merchantPaymentCode' => substr( self::$order->id . '_' . md5( time() ), 0, 40 ),
+				'merchantPaymentCode' => substr( self::$order->get_id() . '_' . md5( time() ), 0, 40 ),
 				'amount'              => self::$order->get_total(),
-				'maxInstalments'      => get_post_meta( self::$order->id, '_ebanx_instalments', true ),
+				'maxInstalments'      => get_post_meta( self::$order->get_id(), '_ebanx_instalments', true ),
 				'manualReview'        => 'yes' === self::$configs->settings['manual_review_enabled'],
 			]
 		);


### PR DESCRIPTION
The PR change how the plugin get the order id from the object, instead use the `$order->id` use the `$order->get_id()`