### PR TITLE
Fix compatibility issue with multi-currency on WooCommerce Subscription renewals

### DIFF
--- a/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -101,7 +101,9 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 		if ( ! is_null( $user_cc_token ) ) {
 			$data = WC_EBANX_Payment_Adapter::transform_card_subscription_payment( $order, $this->configs, $user_cc_token );
 
-			$response = $this->ebanx->creditCard( $this->get_credit_card_config( $country, $order->get_currency() ) )->create( $data );
+			$ebanx = ( new WC_EBANX_Api( $this->configs, $order->get_currency() ) )->ebanx();
+
+			$response = $ebanx->creditCard( $this->get_credit_card_config( $country ) )->create( $data );
 
 			WC_EBANX_Subscription_Renewal_Logger::persist(
 				array(
@@ -353,7 +355,7 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 		$order_amount       = $order->get_total();
 		$instalments_number = get_post_meta( $order->get_id(), '_instalments_number', true ) ?: 1;
 		$country            = trim( strtolower( get_post_meta( $order->get_id(), '_billing_country', true ) ) );
-		$currency           = $order->get_order_currency();
+		$currency           = $order->get_currency();
 
 		if ( WC_EBANX_Constants::COUNTRY_BRAZIL === $country && WC_EBANX_Helper::should_apply_taxes() ) {
 			$order_amount += round( ( $order_amount * WC_EBANX_Constants::BRAZIL_TAX ), 2 );
@@ -499,8 +501,8 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 	 *
 	 * @return CreditCardConfig
 	 */
-	private function get_credit_card_config( $country_abbr, $currency_code = false ) {
-		$currency_code = strtolower( ( $currency_code ? $currency_code : get_woocommerce_currency() ) );
+	private function get_credit_card_config( $country_abbr ) {
+		$currency_code = strtolower( get_woocommerce_currency() );
 
 		$credit_card_config = new CreditCardConfig(
 			array(

--- a/gateways/class-wc-ebanx-credit-card-gateway.php
+++ b/gateways/class-wc-ebanx-credit-card-gateway.php
@@ -101,7 +101,7 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 		if ( ! is_null( $user_cc_token ) ) {
 			$data = WC_EBANX_Payment_Adapter::transform_card_subscription_payment( $order, $this->configs, $user_cc_token );
 
-			$response = $this->ebanx->creditCard( $this->get_credit_card_config( $country ) )->create( $data );
+			$response = $this->ebanx->creditCard( $this->get_credit_card_config( $country, $order->get_currency() ) )->create( $data );
 
 			WC_EBANX_Subscription_Renewal_Logger::persist(
 				array(
@@ -495,11 +495,12 @@ abstract class WC_EBANX_Credit_Card_Gateway extends WC_EBANX_New_Gateway {
 	/**
 	 *
 	 * @param string $country_abbr
+	 * @param string $currency_code
 	 *
 	 * @return CreditCardConfig
 	 */
-	private function get_credit_card_config( $country_abbr ) {
-		$currency_code = strtolower( get_woocommerce_currency() );
+	private function get_credit_card_config( $country_abbr, $currency_code = false ) {
+		$currency_code = strtolower( ( $currency_code ? $currency_code : get_woocommerce_currency() ) );
 
 		$credit_card_config = new CreditCardConfig(
 			array(

--- a/lib/Plugin/Services/WC_EBANX_Capture_Payment.php
+++ b/lib/Plugin/Services/WC_EBANX_Capture_Payment.php
@@ -55,7 +55,7 @@ class WC_EBANX_Capture_Payment {
 	 *
 	 * @return array
 	 */
-	public function add_auto_capture_dropdown( $actions ) {
+	public static function add_auto_capture_dropdown( $actions ) {
 		global $theorder;
 
 		if ( is_array( $actions ) && $theorder->get_status() === 'on-hold'
@@ -71,7 +71,7 @@ class WC_EBANX_Capture_Payment {
 	 *
 	 * @param WC_Order $order
 	 */
-	public function capture_from_order_dropdown( $order ) {
+	public static function capture_from_order_dropdown( $order ) {
 		static::capture_payment( $order->get_id() );
 	}
 

--- a/lib/Plugin/Services/WC_EBANX_My_Account.php
+++ b/lib/Plugin/Services/WC_EBANX_My_Account.php
@@ -13,7 +13,7 @@ class WC_EBANX_My_Account {
 	 */
 	public function __construct() {
 		// Actions.
-		add_action( 'woocommerce_order_items_table', array( $this, 'order_details' ) );
+		add_action( 'woocommerce_order_details_after_order_table_items', array( $this, 'order_details' ) );
 		add_action( 'wp_enqueue_scripts', array( $this, 'assets' ), 100 );
 
 		// Filters.

--- a/lib/Plugin/Services/WC_EBANX_Payment_Adapter.php
+++ b/lib/Plugin/Services/WC_EBANX_Payment_Adapter.php
@@ -535,6 +535,10 @@ class WC_EBANX_Payment_Adapter {
 			case 'PE':
 				return get_user_meta( $user_id, '_ebanx_billing_peru_document', true );
 				break;
+			case 'MX':
+				// No document required.
+				return '';
+				break;
 			default:
 				throw new Exception( 'WC_EBANX_Payment_Adapter: INVALID-DOCUMENT' );
 		}

--- a/services/class-wc-ebanx-payment-by-link.php
+++ b/services/class-wc-ebanx-payment-by-link.php
@@ -135,7 +135,7 @@ class WC_EBANX_Payment_By_Link {
 
 		$response = false;
 		try {
-			$response = ( new WC_EBANX_Api( self::$configs, self::$order->get_order_currency() ) )->ebanx()->hosted()->create( $data );
+			$response = ( new WC_EBANX_Api( self::$configs, self::$order->get_currency() ) )->ebanx()->hosted()->create( $data );
 		} catch ( Exception $e ) {
 			self::add_error( $e->getMessage() );
 			self::send_errors();

--- a/templates/debit-card/payment-processing.php
+++ b/templates/debit-card/payment-processing.php
@@ -14,6 +14,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p><strong><?php echo esc_html( sprintf( 'Pago aprobado con éxito, %s.', $customer_name ) ); ?></strong></p>
 <p><strong>Resumo de la compra:</strong></p>
-<p>Valor: <?php echo esc_html( WC_EBANX_Constants::CURRENCY_CODE_USD ); ?> <?php echo esc_html( $order_amount ); ?></p>
+<p>Valor: <?php echo wp_kses_post( wc_price( $order_amount ) ); ?></p>
 <p>Pago realizado en una sola exhibición'</p>
 <p>Gracias por haber comprado con nosotros.'</p>

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -802,8 +802,11 @@ if ( ! class_exists( 'WC_EBANX' ) ) {
 		 * @return void
 		 */
 		public function ebanx_metabox_payment_link_save( $post_id ) {
-			$order        = wc_get_order( $post_id );
-			$checkout_url = get_post_meta( $order->id, '_ebanx_checkout_url', true );
+			$order = wc_get_order( $post_id );
+			if ( ! $order ) {
+				return;
+			}
+			$checkout_url = get_post_meta( $order->get_id(), '_ebanx_checkout_url', true );
 
 			// Check if is an EBANX request.
 			if ( WC_EBANX_Request::has( 'create_ebanx_payment_link' )


### PR DESCRIPTION
Hi,
We detected an issue with subscription renewal in a multicurrency environment. The parent order is saved and pay in the front-end currency (MX$, ARS, ...), but the plugin process the renewal payment (USD).
The PR fixes the issue.

Btw, I fixed some deprecated functions and bugs.