### PR TITLE
Try to fix the CI problem fixing the composer version to 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ before_install:
   - nvm use stable
 
 install:
-  - composer update
+  - composer self-update --1
   - cd $TRAVIS_BUILD_DIR/tests && npm ci
   - cd $TRAVIS_BUILD_DIR
 


### PR DESCRIPTION
Apparently we have a problem with Travis updating the composer's version. This PR update the `.travis.ci` file to make Travis use the composer's version 1.

This is related to PR #845 