### PR TITLE
Update plugin requirements

### DIFF
--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -5,7 +5,7 @@
  * Description: Offer Latin American local payment methods & increase your conversion rates with the solution used by AliExpress, AirBnB and Spotify in Brazil.
  * Author: EBANX
  * Author URI: https://www.ebanx.com/business/en
- * Version: 1.41.3
+ * Version: 1.41.4
  * License: MIT
  * Text Domain: woocommerce-gateway-ebanx
  * Domain Path: /languages

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -9,6 +9,9 @@
  * License: MIT
  * Text Domain: woocommerce-gateway-ebanx
  * Domain Path: /languages
+ * Requires PHP: 5.6
+ * Requires at least: 4.0.0
+ * Tested up to: 5.5.3
  *
  * @package WooCommerce_EBANX
  */


### PR DESCRIPTION
A new set of tests were made and we can set the plugin as tested up to WordPress `5.6.2` and WooCommerce `5.0.0`.