### PR TITLE
validate_document Method shoud be Static

### DIFF
--- a/lib/Plugin/Services/WC_EBANX_Checker.php
+++ b/lib/Plugin/Services/WC_EBANX_Checker.php
@@ -286,7 +286,7 @@ class WC_EBANX_Checker {
 	 *
 	 * @throws Exception Param not found exception.
 	 */
-	public function validate_document() {
+	public static function validate_document() {
 		if (
 			\WC_EBANX_Request::has( 'billing_country' )
 			&& \WC_EBANX_Request::read( 'billing_country' ) === 'AR'


### PR DESCRIPTION
This method should be Static so if PHP error_reporting is "STRICT" the plugin doesn't break the entire checkout.