### PR TITLE
Version bump `2.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,12 @@
 # CHANGELOG
+# 2.0.0
+
+* Add PIX as payment available to Brazil
+* Update dependencies and versions*
+* Add an option to the admin panel to allow the merchant to not require tax ids
+
+> Because of the versions update, we are jumping to the next major version: `2.0.0`. This will break the legacy.
+
 # 1.41.3
 * Fix - Fix compability with some themes [#842](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/842)
 

--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ Integrate your WooCommerce store with the EBANX payment gateway and improve your
 Please, visit the [official plugin page on WordPress store](https://wordpress.org/plugins/ebanx-payment-gateway-for-woocommerce/).
 
 ## Requirements
-* PHP 5.6+
-* Wordpress 4.0+
-* WooCommerce 3.0+
+* PHP 7.3+
+* Wordpress 5.5+
+* WooCommerce 4.5+
 
 ## Installation
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,14 @@ version: '3'
 
 services:
   woocommerce:
-    image: ebanx/woocommerce-gateway-ebanx:1.41.5
+    image: ebanx/woocommerce-gateway-ebanx:2.0.0
     build: .
     environment:
       WORDPRESS_DB_USER: root
       WORDPRESS_DB_PASSWORD: root
       WORDPRESS_DB_NAME: wordpress
       WORDPRESS_DB_HOST: mysql
-      EBANX_WC_PLUGIN_VERSION: 5.4.1
+      EBANX_WC_PLUGIN_VERSION: 5.8.0
       EBANX_STOREFRONT_THEME_VERSION: 3.7.0
       EBANX_ADMIN_USERNAME: ebanx
       EBANX_ADMIN_PASSWORD: ebanx

--- a/readme.txt
+++ b/readme.txt
@@ -1,9 +1,9 @@
 === EBANX Payment Gateway for WooCommerce ===
 Contributors: ebanxwp
 Tags: credit card, boleto, ebanx, woocommerce, payment gateway, latin america, brazil, mexico, argentina, peru, colombia, chile, ecuador, cash payment, local payment, card payment, one-click payment, alternative payments, payment processing
-Requires at least: 4.0
-Tested up to: 4.9
-Stable tag: 1.41.3
+Requires at least: 5.5
+Tested up to: 5.8
+Stable tag: 2.0.0
 License: Apache v2.0
 License URI: http://www.apache.org/licenses/LICENSE-2.0
 
@@ -103,7 +103,7 @@ On the [EBANX Developer’s Academy](https://developers.ebanx.com/integrations/e
   * EBANX Boleto, Cash Payment
   * Hipercard, Elo, and Aura Domestic Credit Cards
   * Online Debit Transfer
-  * EBANX Account, Debit Transfer
+  * EBANX Account, Debit Transfer, PIX
 * Mexico
   * OXXO, Cash Payment
   * Debit & Credit Cards
@@ -148,6 +148,13 @@ Yes, you can.
 
 
 == Changelog ==
+= 2.0.0 =
+* Add PIX as payment available to Brazil
+* Update dependencies and versions*
+* Add an option to the admin panel to allow the merchant to not require tax ids
+
+> Because of the versions update, we are jumping to the next major version: `2.0.0`. This will break the legacy.
+
 = 1.41.3 =
 * Fix - Fix compability with some themes [#842](https://github.com/ebanx/woocommerce-gateway-ebanx/pull/842)
 

--- a/woocommerce-gateway-ebanx.php
+++ b/woocommerce-gateway-ebanx.php
@@ -7,15 +7,15 @@
  * AliExpress, AirBnB and Spotify in Brazil.
  * Author: EBANX
  * Author URI: https://www.ebanx.com/business/en
- * Version: 1.41.5
+ * Version: 2.0.0
  * License: MIT
  * Text Domain: woocommerce-gateway-ebanx
  * Domain Path: /languages
  * Requires PHP: 7.3
  * Requires at least: 5.5.0
- * Tested up to: 5.7.1
+ * Tested up to: 5.8.0
  * WC requires at least: 4.5.0
- * WC tested up to: 5.3.0
+ * WC tested up to: 5.5.2
  *
  * @package WooCommerce_EBANX
  */
@@ -24,9 +24,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-define( 'WC_EBANX_MIN_PHP_VER', '5.6.0' );
-define( 'WC_EBANX_MIN_WC_VER', '2.6.0' );
-define( 'WC_EBANX_MIN_WP_VER', '4.0.0' );
+define( 'WC_EBANX_MIN_PHP_VER', '7.3.0' );
+define( 'WC_EBANX_MIN_WC_VER', '4.5.0' );
+define( 'WC_EBANX_MIN_WP_VER', '5.5.0' );
 define( 'WC_EBANX_DIR', __DIR__ . DIRECTORY_SEPARATOR );
 define( 'WC_EBANX_PLUGIN_DIR_URL', plugin_dir_url( __FILE__ ) . DIRECTORY_SEPARATOR );
 define( 'WC_EBANX_PLUGIN_NAME', WC_EBANX_PLUGIN_DIR_URL . basename( __FILE__ ) );


### PR DESCRIPTION
This will break the legacy because of the PHP version. All merchants who wants to use PIX as a payment method, will need to update the PHP version and run `composer update`.